### PR TITLE
Add Discourse contributor guide contact link to issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -15,3 +15,6 @@ contact_links:
   - name: Contributor guide
     url: https://github.com/arduino/forum-assets/blob/main/docs/CONTRIBUTING.md#contributor-guide
     about: Learn about contributing to this project.
+  - name: Discourse reports and contributions
+    url: https://github.com/discourse/discourse/blob/main/CONTRIBUTING.md#contributing-to-discourse
+    about: Report bugs, request features, or contribute to the Discourse platform used by Arduino Forum.


### PR DESCRIPTION
Although the repository is used as an issue tracker for problems with the Arduino forum software, the scope is limited to the configuration specific to the Arduino Forum. Defects or enhancements to the underlying **Discourse** platform must be submitted to [the upstream project](https://github.com/discourse/discourse).

The ["issue template chooser"](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) page is shown to the contributor when they [initiate an issue creation process](https://github.com/arduino/forum-assets/issues/new/choose). Adding a "contact link" to the [**Discourse** contributor guide](https://github.com/discourse/discourse/blob/main/CONTRIBUTING.md#contributing-to-discourse) in this page will redirect contributors to the appropriate channel for submitting those reports.

![image](https://user-images.githubusercontent.com/8572152/224998415-0070a0ea-441a-4c2f-a318-5633ebc271e3.png)
