### PR TITLE
Update redirecting links in asset posts

### DIFF
--- a/content/categories/community/project-hub/_topics/about-the-project-hub-category/1.md
+++ b/content/categories/community/project-hub/_topics/about-the-project-hub-category/1.md
@@ -1,8 +1,8 @@
 ## This category is to let us know about bugs/ideas on Arduino Project Hub
 
 Hi!
-This board is just to let us know about bugs on [create.arduino.cc/projecthub](https://create.arduino.cc/projecthub), thank you for reporting any issue or for sharing any idea.
+This board is just to let us know about bugs on [create.arduino.cc/projecthub](https://projecthub.arduino.cc/), thank you for reporting any issue or for sharing any idea.
 
-If you have questions on your project please post them on the [Project Guidance section](https://forum.arduino.cc/index.php?board=3.0). If you instead have issues with the code post on the [Programming Questions section](https://forum.arduino.cc/index.php?board=4.0).
+If you have questions on your project please post them on the [Project Guidance section](https://forum.arduino.cc/c/using-arduino/project-guidance/19). If you instead have issues with the code post on the [Programming Questions section](https://forum.arduino.cc/c/using-arduino/programming-questions/20).
 
 Thanks a lot!

--- a/content/categories/development/suggestions-for-the-arduino-project/_topics/important-notice/1.md
+++ b/content/categories/development/suggestions-for-the-arduino-project/_topics/important-notice/1.md
@@ -6,9 +6,9 @@ http://github.com/arduino/Arduino/issues
 
 - More complex requests and technical discussion should go on the Arduino Developers
 mailing list:
-https://groups.google.com/a/arduino.cc/forum/#!forum/developers
+https://groups.google.com/a/arduino.cc/g/developers
 
 - If you're interested in modifying or extending the Arduino software, we strongly suggest discussing your ideas on the Developers list **before starting** to work on them. That way you can coordinate with the Arduino team and others, giving your work a higher chance of being integrating into the official software
-https://groups.google.com/a/arduino.cc/forum/#!forum/developers
+https://groups.google.com/a/arduino.cc/g/developers
 
 This forum isn't regularly read by Arduino Team and we're considering phasing it out in favor of the options listed above.

--- a/content/categories/hardware/arduino-education-kits/arduino-starter-kit-classroom-pack/_topics/about-the-arduino-starter-kit-classroom-pack-category/1.md
+++ b/content/categories/hardware/arduino-education-kits/arduino-starter-kit-classroom-pack/_topics/about-the-arduino-starter-kit-classroom-pack-category/1.md
@@ -1,1 +1,1 @@
-https://store.arduino.cc/arduino-starter-kit-classroom-pack
+https://store.arduino.cc/products/arduino-starter-kit-classroom-pack

--- a/content/categories/hardware/arduino-education-kits/ctc-go/_topics/about-the-ctc-go-category/1.md
+++ b/content/categories/hardware/arduino-education-kits/ctc-go/_topics/about-the-ctc-go-category/1.md
@@ -1,1 +1,1 @@
-https://store.arduino.cc/ctc-go-core
+https://store.arduino.cc/products/arduino-ctc-go-core-module

--- a/content/categories/hardware/arduino-starter-kit/_topics/about-the-the-arduino-starter-kit/1.md
+++ b/content/categories/hardware/arduino-starter-kit/_topics/about-the-the-arduino-starter-kit/1.md
@@ -1,6 +1,6 @@
 Quickly and easily get started with learning electronics using the Arduino Starter Kit, which have a universal appeal to STEAM fans at home, businesses in STEAM industries, and schools alike. No prior experience is required, as the kits introduce both coding and electronics through fun, engaging, and hands-on projects. You can use the starter kit to teach students about current, voltage, and digital logic as well as the fundamentals of programming. There’s an introduction to sensors and actuators and how to understand both digital and analog signals. Within all this, you’ll be teaching students how to think critically, learn collaboratively, and solve problems.
 
-https://store.arduino.cc/genuino-starter-kit
+https://store.arduino.cc/products/arduino-starter-kit-multi-language
 
 ![](upload://t4HCMr3Sd489eJVbKzISby008UI.jpeg)
 

--- a/content/categories/hardware/arduino-yun/yun-shield/_topics/about-the-yun-shield-category/1.md
+++ b/content/categories/hardware/arduino-yun/yun-shield/_topics/about-the-yun-shield-category/1.md
@@ -1,1 +1,1 @@
-https://www.arduino.cc/en/Guide/ArduinoYunShield
+https://docs.arduino.cc/retired/getting-started-guides/ArduinoYunShield

--- a/content/categories/hardware/mkr-boards/mkr1000-old/_topics/about-the-mkr1000-old-category/1.md
+++ b/content/categories/hardware/mkr-boards/mkr1000-old/_topics/about-the-mkr1000-old-category/1.md
@@ -1,1 +1,1 @@
-https://www.arduino.cc/en/Guide/MKR1000
+https://docs.arduino.cc/hardware/mkr-1000-wifi

--- a/content/categories/hardware/mkr-boards/mkrfox1200/_topics/about-the-mkrfox1200-category/1.md
+++ b/content/categories/hardware/mkr-boards/mkrfox1200/_topics/about-the-mkrfox1200-category/1.md
@@ -1,1 +1,1 @@
-https://www.arduino.cc/en/Guide/MKRFox1200
+https://docs.arduino.cc/hardware/mkr-fox-1200

--- a/content/categories/hardware/mkr-boards/mkrgsm1400/_topics/about-the-mkrgsm1400-category/1.md
+++ b/content/categories/hardware/mkr-boards/mkrgsm1400/_topics/about-the-mkrgsm1400-category/1.md
@@ -1,1 +1,1 @@
-https://www.arduino.cc/en/Guide/MKRGSM1400
+https://docs.arduino.cc/hardware/mkr-gsm-1400

--- a/content/categories/hardware/mkr-boards/mkrnb1500/_topics/about-the-mkrnb1500-category/1.md
+++ b/content/categories/hardware/mkr-boards/mkrnb1500/_topics/about-the-mkrnb1500-category/1.md
@@ -1,1 +1,1 @@
-https://www.arduino.cc/en/Guide/MKRNB1500
+https://docs.arduino.cc/hardware/mkr-nb-1500

--- a/content/categories/hardware/mkr-boards/mkrwan1300/_topics/about-the-mkrwan1300-category/1.md
+++ b/content/categories/hardware/mkr-boards/mkrwan1300/_topics/about-the-mkrwan1300-category/1.md
@@ -1,1 +1,1 @@
-https://www.arduino.cc/en/Guide/MKRWAN1300
+https://docs.arduino.cc/hardware/mkr-wan-1300

--- a/content/categories/hardware/nano-family/nano-33-ble-sense/_topics/about-the-nano-33-ble-sense/1.md
+++ b/content/categories/hardware/nano-family/nano-33-ble-sense/_topics/about-the-nano-33-ble-sense/1.md
@@ -8,6 +8,6 @@ It comes with a series of embedded sensors:
 * microphone: to capture and analyze sound in real time
 * gesture, proximity, light color and light intensity sensor : estimate the room's luminosity, but also whether someone is moving close to the board
 
-https://store.arduino.cc/arduino-nano-33-ble-sense
+https://store.arduino.cc/products/arduino-nano-33-ble
 
 ![](upload://yB1tsZjDfGrJhp7jUkhzIgfgXAf.jpeg)

--- a/content/categories/hardware/nano-family/nano-33-ble/_topics/about-the-nano-33-ble/1.md
+++ b/content/categories/hardware/nano-family/nano-33-ble/_topics/about-the-nano-33-ble/1.md
@@ -6,4 +6,4 @@ The Arduino Nano 33 BLE is an evolution of the traditional Arduino Nano, but fea
 
 The Nano 33 BLE comes with a 9 axis inertial measurement unit (IMU) which means that it includes an accelerometer, a gyroscope, and a magnetometer with 3-axis resolution each. This makes the Nano 33 BLE the perfect choice for more advanced robotics experiments, exercise trackers, digital compasses, etc.
 
-https://store.arduino.cc/arduino-nano-33-ble
+https://store.arduino.cc/products/arduino-nano-33-ble

--- a/content/categories/hardware/nano-family/nano-33-iot/_topics/about-the-nano-33-iot/1.md
+++ b/content/categories/hardware/nano-family/nano-33-iot/_topics/about-the-nano-33-iot/1.md
@@ -1,3 +1,3 @@
 The ease of use of a Nano board with the addition of secure IoT and BT connectivity.
 
-https://store.arduino.cc/arduino-nano-33-iot
+https://store.arduino.cc/products/arduino-nano-33-iot

--- a/content/categories/hardware/nano-family/nano-every/_topics/about-the-nano-every/1.md
+++ b/content/categories/hardware/nano-family/nano-every/_topics/about-the-nano-every/1.md
@@ -1,3 +1,3 @@
 The Arduino Nano Every is an evolution of the traditional Arduino Nano board, but features a lot more powerful processor, the ATmega4809. This will allow you to make larger programs than with the Arduino Uno (it has 50% more program memory), and with a lot more variables (the RAM is 200% bigger).
 
-https://store.arduino.cc/arduino-nano-every
+https://store.arduino.cc/products/arduino-nano-every

--- a/content/categories/hardware/nano-family/nano/_topics/about-the-arduino-nano/1.md
+++ b/content/categories/hardware/nano-family/nano/_topics/about-the-arduino-nano/1.md
@@ -1,3 +1,3 @@
 The Arduino Nano is a small, complete, and breadboard-friendly board based on the ATmega328P (Arduino Nano 3.x).
 
-https://store.arduino.cc/arduino-nano
+https://store.arduino.cc/products/arduino-nano

--- a/content/categories/hardware/portenta/_topics/about-the-portenta-category/1.md
+++ b/content/categories/hardware/portenta/_topics/about-the-portenta-category/1.md
@@ -4,4 +4,4 @@ These products provide outstanding performance and industry-grade security, leve
 
 More information about the **Portenta** family:
 
-https://www.arduino.cc/pro/hardware/product-family/portenta-family?id=25729177
+https://docs.arduino.cc/#portenta-family

--- a/content/categories/software/arduino-cli/_topics/about-the-arduino-command-line-tools-category/1.md
+++ b/content/categories/software/arduino-cli/_topics/about-the-arduino-command-line-tools-category/1.md
@@ -1,8 +1,8 @@
 Welcome to the forum board for Arduino CLI!
 
-Arduino CLI is a tool for [compiling](https://arduino.github.io/arduino-cli/commands/arduino-cli_compile/) and [uploading](https://arduino.github.io/arduino-cli/commands/arduino-cli_upload/) Arduino sketches, [installing libraries](https://arduino.github.io/arduino-cli/commands/arduino-cli_lib/), and [managing boards](https://arduino.github.io/arduino-cli/commands/arduino-cli_core/). It is the heart of the Arduino IDE, Arduino Web Editor, and Arduino Pro IDE.
+Arduino CLI is a tool for [compiling](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_compile/) and [uploading](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_upload/) Arduino sketches, [installing libraries](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_lib/), and [managing boards](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_core/). It is the heart of the Arduino IDE, Arduino Web Editor, and Arduino Pro IDE.
 
-As the "CLI" (command line interface) part of its name suggests, Arduino CLI may be used from the command line. In addition, Arduino CLI provides a [gRPC interface](https://arduino.github.io/arduino-cli/rpc/commands/) and can be used as a Go module, which permits powerful integration with other software.
+As the "CLI" (command line interface) part of its name suggests, Arduino CLI may be used from the command line. In addition, Arduino CLI provides a [gRPC interface](https://arduino.github.io/arduino-cli/latest/rpc/commands/) and can be used as a Go module, which permits powerful integration with other software.
 
 This forum board is for any questions you have about using Arduino CLI.
 

--- a/content/categories/software/chrome-app/_topics/about-the-chrome-app-category/1.md
+++ b/content/categories/software/chrome-app/_topics/about-the-chrome-app-category/1.md
@@ -1,3 +1,3 @@
-The [Arduino Create Chrome App for Education](https://create.arduino.cc/plans/chrome-app) allows students to write code and upload sketches to official Arduino boards.
+The [Arduino Create Chrome App for Education](https://chrome.google.com/webstore/detail/arduino-create-for-educat/elmgohdonjdampbcgefphnlchgocpaij) allows students to write code and upload sketches to official Arduino boards.
 
 Arduino Create is hosted online, therefore it will always be up-to-date with the latest features and support for new boards. Students' sketchbooks are saved on the cloud, always backed up and accessible from any device.

--- a/content/categories/software/editor/_topics/about-the-web-editor-category/1.md
+++ b/content/categories/software/editor/_topics/about-the-web-editor-category/1.md
@@ -1,1 +1,1 @@
-https://create.arduino.cc/projecthub/Arduino_Genuino/getting-started-with-arduino-web-editor-on-various-platforms-4b3e4a
+https://docs.arduino.cc/arduino-cloud/getting-started/getting-started-web-editor

--- a/content/categories/software/iot-cloud/_topics/about-the-iot-cloud-category/1.md
+++ b/content/categories/software/iot-cloud/_topics/about-the-iot-cloud-category/1.md
@@ -2,7 +2,7 @@ Arduino IoT Cloud is a powerful service, allowing **anyone** to create IoT appli
 
 The latest version of the Arduino IoT Cloud includes features such as:
 
-* Directly linked to the [Create Environment](https://create.arduino.cc/).
+* Directly linked to the [Create Environment](https://cloud.arduino.cc/).
 * Automatically generated sketches.
 * Building sensor networks.
 * Real time data monitoring.
@@ -10,4 +10,4 @@ The latest version of the Arduino IoT Cloud includes features such as:
 * Build a dashboard with 15+ unique widgets.
 * Create your own app by using [Arduino IoT API](https://www.arduino.cc/reference/en/iot/api/).
 
-You can find out more about the features in the [Getting started with the Arduino IoT Cloud](https://www.arduino.cc/en/Tutorial/iot-cloud-getting-started).
+You can find out more about the features in the [Getting started with the Arduino IoT Cloud](https://docs.arduino.cc/arduino-cloud/getting-started/iot-cloud-getting-started).

--- a/content/categories/templates/_topics/general-user-advice/1.md
+++ b/content/categories/templates/_topics/general-user-advice/1.md
@@ -14,11 +14,11 @@ It will help you get the best out of the forum in the future.
 **COMMON ISSUES**
 
 * Ensure you have **FULLY** inserted the USB cables.
-* Check you have a [COMMON GROUND](https://forum.arduino.cc/index.php?topic=653831.msg4406618#msg4406618) where required. ( Thanks @Perry)
+* Check you have a [COMMON GROUND](https://forum.arduino.cc/t/common-ground-and-why-you-need-one/626215) where required. ( Thanks @Perry)
 * Where possible use USB 2.0 ports or a USB 2.0 POWERED HUB to rule out USB 3.0 issues.
 * Try other computers where possible.
 * Try other USB leads where possible.
-* You may not have the correct driver installed. [CH340/341](http://www.wch.cn/download/CH341SER_EXE.html) or [CP2102](https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers) or FT232 https://ftdichip.com/drivers/vcp-drivers/
+* You may not have the correct driver installed. [CH340/341](http://www.wch.cn/download/CH341SER_EXE.html) or [CP2102](https://www.silabs.com/developers/usb-to-uart-bridge-vcp-drivers) or FT232 https://ftdichip.com/drivers/vcp-drivers/
 * There may be a problem with the board check or remove your wiring first.
 * Remove any items connected to pins 0 and 1.
 
@@ -37,8 +37,8 @@ It will help you get the best out of the forum in the future.
 
 * CH340/341 based clones do not report useful information to the “get board info” button.
 * NANO (Old Types) some require you to use the OLD BOOTLOADER option.
-* NANO (**ALL Types**) See the [specific sections](https://forum.arduino.cc/index.php?board=135.0) lower in the forum.
-* NANO (**NEW Types**) [Install your board CORE’s.](https://forum.arduino.cc/index.php?topic=642505.0)
+* NANO (**ALL Types**) See the [specific sections](https://forum.arduino.cc/c/hardware/nano-family/87) lower in the forum.
+* NANO (**NEW Types**) [Install your board CORE’s.](https://forum.arduino.cc/t/new-to-the-nano-33-ble-sense-iot-please-read-this-first/616940)
 * Unless using EXTERNAL PROGRAMMERS please leave the IDE selection at default “AVRISP mkII”.
 * Boards using a MICRO usb connector need a cable that is both DATA and CHARGE. Many are CHARGE ONLY.
 
@@ -52,15 +52,15 @@ It will help you get the best out of the forum in the future.
 ****Language problem ?****
 **Try a language closer to your native language:**
 
-* [中文 (Chinese)](https://forum.arduino.cc/index.php?board=99.0)
-* [Deutsch - German](https://forum.arduino.cc/index.php?board=31.0)
-* [Español - Spanish](https://forum.arduino.cc/index.php?board=32.0)
-* [Français - French](https://forum.arduino.cc/index.php?board=33.0)
-* [অসমীয়া, বাংলা, बड़ो - India](https://forum.arduino.cc/index.php?board=82.0)
-* [Italiano - Italian](https://forum.arduino.cc/index.php?board=34.0)
-* [Nederlands - Dutch](https://forum.arduino.cc/index.php?board=77.0)
-* [Portugues - Portuguese](https://forum.arduino.cc/index.php?board=35.0)
-* [Россия - Russia](https://forum.arduino.cc/index.php?board=120.0)
-* [Scandinavia Swedish, Suomi - Finnish, Norsk - Norwegian](https://forum.arduino.cc/index.php?board=36.0)
+* [中文 (Chinese)](https://forum.arduino.cc/c/international/chinese/75)
+* [Deutsch - German](https://forum.arduino.cc/c/international/deutsch/47)
+* [Español - Spanish](https://forum.arduino.cc/c/international/espanol/48)
+* [Français - French](https://forum.arduino.cc/c/international/francais/49)
+* [অসমীয়া, বাংলা, बड़ो - India](https://forum.arduino.cc/c/international/india/62)
+* [Italiano - Italian](https://forum.arduino.cc/c/international/italiano/50)
+* [Nederlands - Dutch](https://forum.arduino.cc/c/international/nederlands/61)
+* [Portugues - Portuguese](https://forum.arduino.cc/c/international/portugues/51)
+* [Россия - Russia](https://forum.arduino.cc/c/international/russia/82)
+* [Scandinavia Swedish, Suomi - Finnish, Norsk - Norwegian](https://forum.arduino.cc/c/international/scandinavia/52)
 
 **Thanks to all those who helped and added to this list.**

--- a/content/categories/using-arduino/installation-troubleshooting/_topics/how-to-get-the-best-out-of-this-forum/1.md
+++ b/content/categories/using-arduino/installation-troubleshooting/_topics/how-to-get-the-best-out-of-this-forum/1.md
@@ -56,7 +56,7 @@ It is very important to be clear about what is expected from code and what happe
 
 The language of electronics is a schematic or circuit diagram. Long descriptions of what is connected to what are generally useless. A schematic is a drawing of what connects to what; please make one and photograph it. We don't mind if it's hand drawn, scruffy and does not use the correct symbols. Please don't post Fritzing diagrams. They may look nice but they are very easy to misinterpret
 
-If you want to use computer software to create a schematic, then you might like to try either [Eagle](https://www.autodesk.co.uk/products/eagle/free-download?plc=F360&term=1-YEAR&support=ADVANCED&quantity=1) or [KiCad](https://kicad.org/).
+If you want to use computer software to create a schematic, then you might like to try either [Eagle](https://www.autodesk.co.uk/products/eagle/free-download?plc=F360&term=1-YEAR&support=ADVANCED&quantity=1) or [KiCad](https://www.kicad.org/).
 [More about creating a schematic of your project including how to upload an image.](https://forum.arduino.cc/t/how-to-make-a-schematic-you-can-post/675103)
 
 <a name="general"></a>


### PR DESCRIPTION
Some of these were not properly redirected to the original target of the link.

Others were eventually reaching the intended target, but it is best to avoid unnecessary reliance on redirects because they tend to go bad over time.