### PR TITLE
Add category permissions data

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -72,6 +72,9 @@
       "pattern": "^https://forum\\.arduino\\.cc/t/about-the-staff-category/2$"
     },
     {
+      "pattern": "^https://forum.arduino.cc/t/about-the-recycle-bin-category/847560$"
+    },
+    {
       "pattern": "^https://forum\\.arduino\\.cc/t/about-the-templates-category/1087943$"
     },
     {

--- a/content/categories/README.md
+++ b/content/categories/README.md
@@ -2,6 +2,12 @@
 
 This folder uses a tree structure based on the Arduino Forum category structure.
 
+## Permissions
+
+The "**See**" (view category and topics), "**Reply**" (reply to topics), and "**Create**" (create topics) permissions of a category can be set for each of [the forum's user groups](https://forum.arduino.cc/g). The permissions of each category are shown in a table in the "**Permissions**" section of the `README.md` file under the category folders.
+
+The special "**everyone**" group is used to set category permissions that are universal to all forum users regardless of the specific groups they are a member of.
+
 ## Notes
 
 - The content of the "**About the \_\_\_\_\_ category**" topics is used as the category description in the category listings.

--- a/content/categories/community/README.md
+++ b/content/categories/community/README.md
@@ -1,5 +1,11 @@
 # Community
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
+
 ## Published At
 
 https://forum.arduino.cc/c/community/9

--- a/content/categories/community/bar-sport/README.md
+++ b/content/categories/community/bar-sport/README.md
@@ -1,5 +1,11 @@
 # Bar Sport
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/community/bar-sport/46

--- a/content/categories/community/exhibition-gallery/README.md
+++ b/content/categories/community/exhibition-gallery/README.md
@@ -1,5 +1,11 @@
 # Exhibition / Gallery
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/community/exhibition-gallery/45

--- a/content/categories/community/general-discussion/README.md
+++ b/content/categories/community/general-discussion/README.md
@@ -1,5 +1,11 @@
 # General Discussion
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/community/general-discussion/17

--- a/content/categories/community/jobs/README.md
+++ b/content/categories/community/jobs/README.md
@@ -1,5 +1,11 @@
 # Jobs and Paid Consultancy
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/community/jobs/42

--- a/content/categories/community/local-groups/README.md
+++ b/content/categories/community/local-groups/README.md
@@ -1,5 +1,11 @@
 # Local Groups
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/community/local-groups/44

--- a/content/categories/community/products-and-services/README.md
+++ b/content/categories/community/products-and-services/README.md
@@ -1,5 +1,11 @@
 # Products and Services
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/community/products-and-services/41

--- a/content/categories/community/project-hub/README.md
+++ b/content/categories/community/project-hub/README.md
@@ -1,5 +1,11 @@
 # Project Hub
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/community/project-hub/138

--- a/content/categories/community/website-and-forum/README.md
+++ b/content/categories/community/website-and-forum/README.md
@@ -1,5 +1,11 @@
 # Website and Forum
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/community/website-and-forum/40

--- a/content/categories/community/workshops-and-events/README.md
+++ b/content/categories/community/workshops-and-events/README.md
@@ -1,5 +1,11 @@
 # Workshops and Events
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/community/workshops-and-events/43

--- a/content/categories/community/workshops-and-events/events-and-tour/README.md
+++ b/content/categories/community/workshops-and-events/events-and-tour/README.md
@@ -1,5 +1,11 @@
 # Events and Tour
 
+## Permissions
+
+| Group | See | Reply | Create |
+| ----- | --- | ----- | ------ |
+| staff | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/community/workshops-and-events/events-and-tour/68 (private)

--- a/content/categories/community/workshops-and-events/makers/README.md
+++ b/content/categories/community/workshops-and-events/makers/README.md
@@ -1,5 +1,11 @@
 # Makers
 
+## Permissions
+
+| Group | See | Reply | Create |
+| ----- | --- | ----- | ------ |
+| staff | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/community/workshops-and-events/makers/67 (private)

--- a/content/categories/development/README.md
+++ b/content/categories/development/README.md
@@ -1,5 +1,11 @@
 # Development
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
+
 ## Published At
 
 https://forum.arduino.cc/c/development/8

--- a/content/categories/development/libraries/README.md
+++ b/content/categories/development/libraries/README.md
@@ -1,5 +1,11 @@
 # Libraries
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/development/libraries/39

--- a/content/categories/development/other-hardware-development/README.md
+++ b/content/categories/development/other-hardware-development/README.md
@@ -1,5 +1,11 @@
 # Other Hardware Development
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/development/other-hardware-development/38

--- a/content/categories/development/suggestions-for-the-arduino-project/README.md
+++ b/content/categories/development/suggestions-for-the-arduino-project/README.md
@@ -1,5 +1,11 @@
 # Suggestions for the Arduino Project
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/development/suggestions-for-the-arduino-project/37

--- a/content/categories/forum-2005-2010-read-only/README.md
+++ b/content/categories/forum-2005-2010-read-only/README.md
@@ -1,5 +1,11 @@
 # Forum 2005-2010 (read only)
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
+
 ## Published At
 
 https://forum.arduino.cc/c/forum-2005-2010-read-only/11

--- a/content/categories/garbage/README.md
+++ b/content/categories/garbage/README.md
@@ -1,5 +1,11 @@
 # Garbage
 
+## Permissions
+
+| Group | See | Reply | Create |
+| ----- | --- | ----- | ------ |
+| staff | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/garbage/119 (private)

--- a/content/categories/garbage/recycle-bin/README.md
+++ b/content/categories/garbage/recycle-bin/README.md
@@ -1,5 +1,11 @@
 # Recycle Bin
 
+## Permissions
+
+| Group | See | Reply | Create |
+| ----- | --- | ----- | ------ |
+| staff | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/garbage/recycle-bin/120

--- a/content/categories/garbage/recycle-bin/README.md
+++ b/content/categories/garbage/recycle-bin/README.md
@@ -1,0 +1,5 @@
+# Recycle Bin
+
+## Published At
+
+https://forum.arduino.cc/c/garbage/recycle-bin/120

--- a/content/categories/garbage/recycle-bin/_pins.md
+++ b/content/categories/garbage/recycle-bin/_pins.md
@@ -1,0 +1,1 @@
+- https://forum.arduino.cc/t/about-the-recycle-bin-category/847560

--- a/content/categories/garbage/recycle-bin/_topics/about-the-recycle-bin-category/1.md
+++ b/content/categories/garbage/recycle-bin/_topics/about-the-recycle-bin-category/1.md
@@ -1,0 +1,1 @@
+This is the board where the post deleted by users (mostly accidentally) will end up

--- a/content/categories/garbage/recycle-bin/_topics/about-the-recycle-bin-category/README.md
+++ b/content/categories/garbage/recycle-bin/_topics/about-the-recycle-bin-category/README.md
@@ -1,0 +1,5 @@
+# About the Recycle Bin category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-recycle-bin-category/847560

--- a/content/categories/hardware/README.md
+++ b/content/categories/hardware/README.md
@@ -1,5 +1,11 @@
 # Hardware
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/12

--- a/content/categories/hardware/arduino-101/README.md
+++ b/content/categories/hardware/arduino-101/README.md
@@ -1,5 +1,11 @@
 # Arduino 101
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/arduino-101/77

--- a/content/categories/hardware/arduino-due/README.md
+++ b/content/categories/hardware/arduino-due/README.md
@@ -1,5 +1,11 @@
 # Arduino Due
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/arduino-due/64

--- a/content/categories/hardware/arduino-education-kits/README.md
+++ b/content/categories/hardware/arduino-education-kits/README.md
@@ -1,5 +1,11 @@
 # Arduino Education Kits
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/arduino-education-kits/83

--- a/content/categories/hardware/arduino-education-kits/arduino-engineering-kit/README.md
+++ b/content/categories/hardware/arduino-education-kits/arduino-engineering-kit/README.md
@@ -1,5 +1,11 @@
 # Arduino Engineering Kit
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/arduino-education-kits/arduino-engineering-kit/149

--- a/content/categories/hardware/arduino-education-kits/arduino-science-journal-arduino-science-kit/README.md
+++ b/content/categories/hardware/arduino-education-kits/arduino-science-journal-arduino-science-kit/README.md
@@ -1,5 +1,11 @@
 # Arduino Science Journal & Arduino Science Kit
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/arduino-education-kits/arduino-science-journal-arduino-science-kit/154

--- a/content/categories/hardware/arduino-education-kits/arduino-starter-kit-classroom-pack/README.md
+++ b/content/categories/hardware/arduino-education-kits/arduino-starter-kit-classroom-pack/README.md
@@ -1,5 +1,11 @@
 # Arduino Starter Kit Classroom Pack
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/arduino-education-kits/arduino-starter-kit-classroom-pack/151

--- a/content/categories/hardware/arduino-education-kits/ctc-101/README.md
+++ b/content/categories/hardware/arduino-education-kits/ctc-101/README.md
@@ -1,5 +1,11 @@
 # CTC 101
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/arduino-education-kits/ctc-101/148

--- a/content/categories/hardware/arduino-education-kits/ctc-go/README.md
+++ b/content/categories/hardware/arduino-education-kits/ctc-go/README.md
@@ -1,5 +1,11 @@
 # CTC GO!
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/arduino-education-kits/ctc-go/153

--- a/content/categories/hardware/arduino-esplora/README.md
+++ b/content/categories/hardware/arduino-esplora/README.md
@@ -1,5 +1,11 @@
 # Arduino Esplora
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/arduino-esplora/65

--- a/content/categories/hardware/arduino-gsm-shield/README.md
+++ b/content/categories/hardware/arduino-gsm-shield/README.md
@@ -1,5 +1,11 @@
 # Arduino GSM Shield
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/arduino-gsm-shield/66

--- a/content/categories/hardware/arduino-starter-kit/README.md
+++ b/content/categories/hardware/arduino-starter-kit/README.md
@@ -1,5 +1,11 @@
 # The Arduino Starter Kit
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/arduino-starter-kit/63

--- a/content/categories/hardware/arduino-wifi-rev2/README.md
+++ b/content/categories/hardware/arduino-wifi-rev2/README.md
@@ -1,5 +1,11 @@
 # Arduino WiFi Rev2
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/arduino-wifi-rev2/84

--- a/content/categories/hardware/arduino-yun/README.md
+++ b/content/categories/hardware/arduino-yun/README.md
@@ -1,5 +1,11 @@
 # Arduino Yún
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/arduino-yun/69

--- a/content/categories/hardware/arduino-yun/yun-shield/README.md
+++ b/content/categories/hardware/arduino-yun/yun-shield/README.md
@@ -1,5 +1,11 @@
 # Yún Shield
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/arduino-yun/yun-shield/139

--- a/content/categories/hardware/arduino-zero/README.md
+++ b/content/categories/hardware/arduino-zero/README.md
@@ -1,5 +1,11 @@
 # Arduino Zero
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/arduino-zero/74

--- a/content/categories/hardware/giga-r1/README.md
+++ b/content/categories/hardware/giga-r1/README.md
@@ -1,5 +1,11 @@
 # GIGA R1
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/giga-r1/182

--- a/content/categories/hardware/materia-101/README.md
+++ b/content/categories/hardware/materia-101/README.md
@@ -1,5 +1,11 @@
 # Materia 101
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/materia-101/70

--- a/content/categories/hardware/mkr-boards/README.md
+++ b/content/categories/hardware/mkr-boards/README.md
@@ -1,5 +1,11 @@
 # MKR Family
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/mkr-boards/79

--- a/content/categories/hardware/mkr-boards/mkr-shields/README.md
+++ b/content/categories/hardware/mkr-boards/mkr-shields/README.md
@@ -1,5 +1,11 @@
 # MKR SHIELDS
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/mkr-boards/mkr-shields/162

--- a/content/categories/hardware/mkr-boards/mkr1000-old/README.md
+++ b/content/categories/hardware/mkr-boards/mkr1000-old/README.md
@@ -1,5 +1,11 @@
 # Mkr1000 [old]
 
+## Permissions
+
+| Group | See | Reply | Create |
+| ----- | --- | ----- | ------ |
+| staff | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/mkr-boards/mkr1000-old/135 (private)

--- a/content/categories/hardware/mkr-boards/mkr1000/README.md
+++ b/content/categories/hardware/mkr-boards/mkr1000/README.md
@@ -1,5 +1,11 @@
 # MKR1000
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/mkr-boards/mkr1000/137

--- a/content/categories/hardware/mkr-boards/mkrfox1200/README.md
+++ b/content/categories/hardware/mkr-boards/mkrfox1200/README.md
@@ -1,5 +1,11 @@
 # MKRFOX1200
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/mkr-boards/mkrfox1200/142

--- a/content/categories/hardware/mkr-boards/mkrgsm1400/README.md
+++ b/content/categories/hardware/mkr-boards/mkrgsm1400/README.md
@@ -1,5 +1,11 @@
 # MKRGSM1400
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/mkr-boards/mkrgsm1400/146

--- a/content/categories/hardware/mkr-boards/mkrnb1500/README.md
+++ b/content/categories/hardware/mkr-boards/mkrnb1500/README.md
@@ -1,5 +1,11 @@
 # MKRNB1500
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/mkr-boards/mkrnb1500/156

--- a/content/categories/hardware/mkr-boards/mkrvidor4000/README.md
+++ b/content/categories/hardware/mkr-boards/mkrvidor4000/README.md
@@ -1,5 +1,11 @@
 # MKRVIDOR4000
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/mkr-boards/mkrvidor4000/150

--- a/content/categories/hardware/mkr-boards/mkrwan1300/README.md
+++ b/content/categories/hardware/mkr-boards/mkrwan1300/README.md
@@ -1,5 +1,11 @@
 # MKRWAN1300
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/mkr-boards/mkrwan1300/145

--- a/content/categories/hardware/mkr-boards/mkrwan1310/README.md
+++ b/content/categories/hardware/mkr-boards/mkrwan1310/README.md
@@ -1,5 +1,11 @@
 # MKRWAN1310
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/mkr-boards/mkrwan1310/161

--- a/content/categories/hardware/mkr-boards/mkrwifi1010/README.md
+++ b/content/categories/hardware/mkr-boards/mkrwifi1010/README.md
@@ -1,5 +1,11 @@
 # MKRWIFI1010
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/mkr-boards/mkrwifi1010/147

--- a/content/categories/hardware/mkr-boards/mkrzero/README.md
+++ b/content/categories/hardware/mkr-boards/mkrzero/README.md
@@ -1,5 +1,11 @@
 # MKRZero
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/mkr-boards/mkrzero/140

--- a/content/categories/hardware/nano-family/README.md
+++ b/content/categories/hardware/nano-family/README.md
@@ -1,5 +1,11 @@
 # Nano Family
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/nano-family/87

--- a/content/categories/hardware/nano-family/nano-33-ble-sense/README.md
+++ b/content/categories/hardware/nano-family/nano-33-ble-sense/README.md
@@ -1,5 +1,11 @@
 # Nano 33 BLE Sense
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/nano-family/nano-33-ble-sense/160

--- a/content/categories/hardware/nano-family/nano-33-ble/README.md
+++ b/content/categories/hardware/nano-family/nano-33-ble/README.md
@@ -1,5 +1,11 @@
 # About the Nano 33 BLE
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/nano-family/nano-33-ble/159

--- a/content/categories/hardware/nano-family/nano-33-iot/README.md
+++ b/content/categories/hardware/nano-family/nano-33-iot/README.md
@@ -1,5 +1,11 @@
 # Nano 33 IoT
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/nano-family/nano-33-iot/157

--- a/content/categories/hardware/nano-family/nano-every/README.md
+++ b/content/categories/hardware/nano-family/nano-every/README.md
@@ -1,5 +1,11 @@
 # Nano Every
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/nano-family/nano-every/158

--- a/content/categories/hardware/nano-family/nano-rp2040-connect/README.md
+++ b/content/categories/hardware/nano-family/nano-rp2040-connect/README.md
@@ -1,5 +1,11 @@
 # Nano RP2040 Connect
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/nano-family/nano-rp2040-connect/165

--- a/content/categories/hardware/nano-family/nano/README.md
+++ b/content/categories/hardware/nano-family/nano/README.md
@@ -1,5 +1,11 @@
 # Classic Nano
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/nano-family/nano/166

--- a/content/categories/hardware/nicla-family/README.md
+++ b/content/categories/hardware/nicla-family/README.md
@@ -1,5 +1,11 @@
 # Nicla family
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/nicla-family/169

--- a/content/categories/hardware/nicla-family/nicla-family/README.md
+++ b/content/categories/hardware/nicla-family/nicla-family/README.md
@@ -1,5 +1,11 @@
 # Nicla Sense ME
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/nicla-family/nicla-family/170

--- a/content/categories/hardware/nicla-family/nicla-vision/README.md
+++ b/content/categories/hardware/nicla-family/nicla-vision/README.md
@@ -1,5 +1,11 @@
 # Nicla Vision
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/nicla-family/nicla-vision/171

--- a/content/categories/hardware/nicla-family/nicla-voice/README.md
+++ b/content/categories/hardware/nicla-family/nicla-voice/README.md
@@ -1,5 +1,11 @@
 # Nicla Voice
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/nicla-family/nicla-voice/180

--- a/content/categories/hardware/opta/README.md
+++ b/content/categories/hardware/opta/README.md
@@ -1,5 +1,11 @@
 # Opta
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/opta/179

--- a/content/categories/hardware/portenta/README.md
+++ b/content/categories/hardware/portenta/README.md
@@ -1,5 +1,11 @@
 # Portenta
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/portenta/91

--- a/content/categories/hardware/portenta/edge-impulse/README.md
+++ b/content/categories/hardware/portenta/edge-impulse/README.md
@@ -1,5 +1,11 @@
 # Edge Control
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/portenta/edge-impulse/178

--- a/content/categories/hardware/portenta/portenta-breakout/README.md
+++ b/content/categories/hardware/portenta/portenta-breakout/README.md
@@ -1,5 +1,11 @@
 # Portenta Breakout
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/portenta/portenta-breakout/174

--- a/content/categories/hardware/portenta/portenta-cat-m1-nb-iot/README.md
+++ b/content/categories/hardware/portenta/portenta-cat-m1-nb-iot/README.md
@@ -1,5 +1,11 @@
 # Portenta CAT.M1/NB IoT GNSS Shield
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/portenta/portenta-cat-m1-nb-iot/176

--- a/content/categories/hardware/portenta/portenta-machine-control/README.md
+++ b/content/categories/hardware/portenta/portenta-machine-control/README.md
@@ -1,5 +1,11 @@
 # Portenta Machine Control
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/portenta/portenta-machine-control/173

--- a/content/categories/hardware/portenta/portenta-max-carrier/README.md
+++ b/content/categories/hardware/portenta/portenta-max-carrier/README.md
@@ -1,5 +1,11 @@
 # Portenta Max Carrier
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/portenta/portenta-max-carrier/175

--- a/content/categories/hardware/portenta/portenta-vision-shield/README.md
+++ b/content/categories/hardware/portenta/portenta-vision-shield/README.md
@@ -1,5 +1,11 @@
 # Portenta Vision Shield
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/portenta/portenta-vision-shield/177

--- a/content/categories/hardware/portenta/portenta-x8/README.md
+++ b/content/categories/hardware/portenta/portenta-x8/README.md
@@ -1,5 +1,11 @@
 # Portenta X8
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/portenta/portenta-x8/172

--- a/content/categories/hardware/portenta/pro-family/README.md
+++ b/content/categories/hardware/portenta/pro-family/README.md
@@ -1,5 +1,11 @@
 # Portenta H7
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/portenta/pro-family/168

--- a/content/categories/hardware/wifi-shield-101/README.md
+++ b/content/categories/hardware/wifi-shield-101/README.md
@@ -1,5 +1,11 @@
 # WiFi Shield 101
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/wifi-shield-101/76

--- a/content/categories/hardware/wisgate-gateways/README.md
+++ b/content/categories/hardware/wisgate-gateways/README.md
@@ -1,5 +1,11 @@
 # WisGate Gateways
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/hardware/wisgate-gateways/167

--- a/content/categories/international/README.md
+++ b/content/categories/international/README.md
@@ -1,5 +1,11 @@
 # International
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
+
 ## Published At
 
 https://forum.arduino.cc/c/international/10

--- a/content/categories/international/india/README.md
+++ b/content/categories/international/india/README.md
@@ -1,5 +1,11 @@
 # India
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/international/india/62

--- a/content/categories/projects/README.md
+++ b/content/categories/projects/README.md
@@ -1,5 +1,11 @@
 # Projects Discussion and Showcase
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
+
 ## Published At
 
 https://forum.arduino.cc/c/projects/7

--- a/content/categories/projects/covid-19-projects/README.md
+++ b/content/categories/projects/covid-19-projects/README.md
@@ -1,5 +1,11 @@
 # Emergency Response: Covid-19 Projects
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/projects/covid-19-projects/88

--- a/content/categories/projects/device-hacking/README.md
+++ b/content/categories/projects/device-hacking/README.md
@@ -1,5 +1,11 @@
 # Device Hacking
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/projects/device-hacking/33

--- a/content/categories/projects/e-textiles-and-craft/README.md
+++ b/content/categories/projects/e-textiles-and-craft/README.md
@@ -1,5 +1,11 @@
 # E-Textiles and Craft
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/projects/e-textiles-and-craft/29

--- a/content/categories/projects/education-and-teaching/README.md
+++ b/content/categories/projects/education-and-teaching/README.md
@@ -1,5 +1,11 @@
 # Education and Teaching
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/projects/education-and-teaching/34

--- a/content/categories/projects/home-automation/README.md
+++ b/content/categories/projects/home-automation/README.md
@@ -1,5 +1,11 @@
 # Home Automation
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/projects/home-automation/32

--- a/content/categories/projects/interactive-art/README.md
+++ b/content/categories/projects/interactive-art/README.md
@@ -1,5 +1,11 @@
 # Interactive Art
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/projects/interactive-art/35

--- a/content/categories/projects/product-design/README.md
+++ b/content/categories/projects/product-design/README.md
@@ -1,5 +1,11 @@
 # Product Design
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/projects/product-design/36

--- a/content/categories/projects/remote-learning/README.md
+++ b/content/categories/projects/remote-learning/README.md
@@ -1,5 +1,11 @@
 # Emergency Response: Remote Learning
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/projects/remote-learning/90

--- a/content/categories/projects/robotics/README.md
+++ b/content/categories/projects/robotics/README.md
@@ -1,5 +1,11 @@
 # Robotics
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/projects/robotics/30

--- a/content/categories/projects/science-and-measurement/README.md
+++ b/content/categories/projects/science-and-measurement/README.md
@@ -1,5 +1,11 @@
 # Science and Measurement
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/projects/science-and-measurement/31

--- a/content/categories/software/README.md
+++ b/content/categories/software/README.md
@@ -1,5 +1,11 @@
 # Software
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
+
 ## Published At
 
 https://forum.arduino.cc/c/software/164

--- a/content/categories/software/arduino-cli/README.md
+++ b/content/categories/software/arduino-cli/README.md
@@ -1,5 +1,11 @@
 # Arduino command line tools
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/software/arduino-cli/89

--- a/content/categories/software/arduino-ide-2-0/README.md
+++ b/content/categories/software/arduino-ide-2-0/README.md
@@ -1,5 +1,11 @@
 # Arduino IDE 2.0
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/software/arduino-ide-2-0/93

--- a/content/categories/software/arduino-sim/README.md
+++ b/content/categories/software/arduino-sim/README.md
@@ -1,5 +1,11 @@
 # Arduino SIM
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/software/arduino-sim/86

--- a/content/categories/software/chrome-app/README.md
+++ b/content/categories/software/chrome-app/README.md
@@ -1,5 +1,11 @@
 # Chrome App
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/software/chrome-app/141

--- a/content/categories/software/cloud/README.md
+++ b/content/categories/software/cloud/README.md
@@ -1,5 +1,11 @@
 # Cloud
 
+## Permissions
+
+| Group | See | Reply | Create |
+| ----- | --- | ----- | ------ |
+| staff | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/software/cloud/136

--- a/content/categories/software/editor/README.md
+++ b/content/categories/software/editor/README.md
@@ -1,5 +1,11 @@
 # Web Editor
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/software/editor/134

--- a/content/categories/software/intel-based-platforms/README.md
+++ b/content/categories/software/intel-based-platforms/README.md
@@ -1,5 +1,11 @@
 # Intel®-based platforms
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/software/intel-based-platforms/144

--- a/content/categories/software/iot-cloud/README.md
+++ b/content/categories/software/iot-cloud/README.md
@@ -1,5 +1,11 @@
 # IoT Cloud
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/software/iot-cloud/152

--- a/content/categories/software/windows-remote-arduino/README.md
+++ b/content/categories/software/windows-remote-arduino/README.md
@@ -1,5 +1,11 @@
 # Windows Remote Arduino
 
+## Permissions
+
+| Group | See | Reply | Create |
+| ----- | --- | ----- | ------ |
+| staff | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/software/windows-remote-arduino/72 (private)

--- a/content/categories/software/windows-virtual-shields-for-arduino/README.md
+++ b/content/categories/software/windows-virtual-shields-for-arduino/README.md
@@ -1,5 +1,11 @@
 # Windows Virtual Shields for Arduino
 
+## Permissions
+
+| Group | See | Reply | Create |
+| ----- | --- | ----- | ------ |
+| staff | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/software/windows-virtual-shields-for-arduino/73 (private)

--- a/content/categories/staff/README.md
+++ b/content/categories/staff/README.md
@@ -1,5 +1,11 @@
 # Staff
 
+## Permissions
+
+| Group | See | Reply | Create |
+| ----- | --- | ----- | ------ |
+| staff | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/staff/3 (private)

--- a/content/categories/staff/moderation/README.md
+++ b/content/categories/staff/moderation/README.md
@@ -1,5 +1,11 @@
 # Moderation
 
+## Permissions
+
+| Group | See | Reply | Create |
+| ----- | --- | ----- | ------ |
+| staff | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/staff/moderation/60 (private)

--- a/content/categories/staff/moderation/policies/README.md
+++ b/content/categories/staff/moderation/policies/README.md
@@ -1,5 +1,11 @@
 # Policies
 
+## Permissions
+
+| Group | See | Reply | Create |
+| ----- | --- | ----- | ------ |
+| staff | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/staff/moderation/policies/118 (private)

--- a/content/categories/staff/test/README.md
+++ b/content/categories/staff/test/README.md
@@ -1,5 +1,11 @@
 # TEST
 
+## Permissions
+
+| Group | See | Reply | Create |
+| ----- | --- | ----- | ------ |
+| staff | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/staff/test/71 (private)

--- a/content/categories/templates/README.md
+++ b/content/categories/templates/README.md
@@ -10,6 +10,13 @@ The Discourse Templates feature is only available for staff members (moderators 
 
 - [Forum topic for related discussion](https://forum.arduino.cc/t/discussion-re-canned-replies/856761) (private)
 
+## Permissions
+
+| Group  | See | Reply | Create |
+| ------ | --- | ----- | ------ |
+| admins | ✓   | ✓     | ✓      |
+| staff  | ✓   |       |        |
+
 ## Published At
 
 https://forum.arduino.cc/c/templates/181 (private)

--- a/content/categories/using-arduino/README.md
+++ b/content/categories/using-arduino/README.md
@@ -1,5 +1,11 @@
 # Using Arduino
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
+
 ## Published At
 
 - https://forum.arduino.cc/c/using-arduino/6

--- a/content/categories/using-arduino/audio/README.md
+++ b/content/categories/using-arduino/audio/README.md
@@ -1,5 +1,11 @@
 # Audio
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/using-arduino/audio/24

--- a/content/categories/using-arduino/avrdude-stk500-bootloader-issues/README.md
+++ b/content/categories/using-arduino/avrdude-stk500-bootloader-issues/README.md
@@ -1,5 +1,11 @@
 # Avrdude, stk500, Bootloader issues
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/using-arduino/avrdude-stk500-bootloader-issues/81

--- a/content/categories/using-arduino/displays/README.md
+++ b/content/categories/using-arduino/displays/README.md
@@ -1,5 +1,11 @@
 # Displays
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/using-arduino/displays/23

--- a/content/categories/using-arduino/general-electronics/README.md
+++ b/content/categories/using-arduino/general-electronics/README.md
@@ -1,5 +1,11 @@
 # General Electronics
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/using-arduino/general-electronics/21

--- a/content/categories/using-arduino/installation-troubleshooting/README.md
+++ b/content/categories/using-arduino/installation-troubleshooting/README.md
@@ -1,5 +1,11 @@
 # Installation & Troubleshooting
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/using-arduino/installation-troubleshooting/18

--- a/content/categories/using-arduino/interfacing-w-software-on-the-computer/README.md
+++ b/content/categories/using-arduino/interfacing-w-software-on-the-computer/README.md
@@ -1,5 +1,11 @@
 # Interfacing w/ Software on the Computer
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/using-arduino/interfacing-w-software-on-the-computer/28

--- a/content/categories/using-arduino/introductory-tutorials/README.md
+++ b/content/categories/using-arduino/introductory-tutorials/README.md
@@ -1,5 +1,11 @@
 # Introductory Tutorials
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/using-arduino/introductory-tutorials/80

--- a/content/categories/using-arduino/leds-and-multiplexing/README.md
+++ b/content/categories/using-arduino/leds-and-multiplexing/README.md
@@ -1,5 +1,11 @@
 # LEDs and Multiplexing
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/using-arduino/leds-and-multiplexing/22

--- a/content/categories/using-arduino/microcontrollers/README.md
+++ b/content/categories/using-arduino/microcontrollers/README.md
@@ -1,5 +1,11 @@
 # Microcontrollers
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/using-arduino/microcontrollers/59

--- a/content/categories/using-arduino/motors-mechanics-power-and-cnc/README.md
+++ b/content/categories/using-arduino/motors-mechanics-power-and-cnc/README.md
@@ -1,5 +1,11 @@
 # Motors, Mechanics, Power and CNC
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/using-arduino/motors-mechanics-power-and-cnc/25

--- a/content/categories/using-arduino/networking-protocols-and-devices/README.md
+++ b/content/categories/using-arduino/networking-protocols-and-devices/README.md
@@ -1,5 +1,11 @@
 # Networking, Protocols, and Devices
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/using-arduino/networking-protocols-and-devices/27

--- a/content/categories/using-arduino/programming-questions/README.md
+++ b/content/categories/using-arduino/programming-questions/README.md
@@ -1,5 +1,11 @@
 # Programming Questions
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/using-arduino/programming-questions/20

--- a/content/categories/using-arduino/project-guidance/README.md
+++ b/content/categories/using-arduino/project-guidance/README.md
@@ -1,5 +1,11 @@
 # Project Guidance
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/using-arduino/project-guidance/19

--- a/content/categories/using-arduino/sensors/README.md
+++ b/content/categories/using-arduino/sensors/README.md
@@ -1,5 +1,11 @@
 # Sensors
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/using-arduino/sensors/26

--- a/content/categories/using-arduino/storage/README.md
+++ b/content/categories/using-arduino/storage/README.md
@@ -1,5 +1,11 @@
 # Storage
 
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
 ## Published At
 
 https://forum.arduino.cc/c/using-arduino/storage/58


### PR DESCRIPTION
The "**See**" (view category and topics), "**Reply**" (reply to topics), and "**Create**" (create topics) permissions of a category can be set for each of [the forum's user groups](https://forum.arduino.cc/g).

Adding this data to the assets repository allows contributors to efficiently make proposals for adjustments of the permissions (e.g., preventing creation of topics in a category that is intended to only serve as a "container" for sub-categories).

The permissions of each category are shown in a table in the "**Permissions**" section of the `README.md` file under the category folders.