### PR TITLE
Add missing alt text to image markup

### DIFF
--- a/content/categories/hardware/arduino-starter-kit/_topics/about-the-the-arduino-starter-kit/1.md
+++ b/content/categories/hardware/arduino-starter-kit/_topics/about-the-the-arduino-starter-kit/1.md
@@ -2,8 +2,8 @@ Quickly and easily get started with learning electronics using the Arduino Start
 
 https://store.arduino.cc/products/arduino-starter-kit-multi-language
 
-![](upload://t4HCMr3Sd489eJVbKzISby008UI.jpeg)
+![Front of box](upload://t4HCMr3Sd489eJVbKzISby008UI.jpeg)
 
-![](upload://ryY24FVj9t7NGWfFRTvcYwOT32f.jpeg)
+![Back of box](upload://ryY24FVj9t7NGWfFRTvcYwOT32f.jpeg)
 
-![](upload://jsY5LC2FihrGykoYM5jGcepiPeY.jpeg)
+![Kit contents](upload://jsY5LC2FihrGykoYM5jGcepiPeY.jpeg)

--- a/content/categories/hardware/nano-family/nano-33-ble-sense/_topics/about-the-nano-33-ble-sense/1.md
+++ b/content/categories/hardware/nano-family/nano-33-ble-sense/_topics/about-the-nano-33-ble-sense/1.md
@@ -10,4 +10,4 @@ It comes with a series of embedded sensors:
 
 https://store.arduino.cc/products/arduino-nano-33-ble
 
-![](upload://yB1tsZjDfGrJhp7jUkhzIgfgXAf.jpeg)
+![Nano 33 BLE Sense](upload://yB1tsZjDfGrJhp7jUkhzIgfgXAf.jpeg)


### PR DESCRIPTION
["Alternate text"](https://en.wikipedia.org/wiki/Alt_attribute) is important for accessibility and describes the content of an image for people who may not be able to see it.

For this reason, the excellent [**markdownlint**](https://github.com/DavidAnson/markdownlint) tool is used to [detect missing alternate text](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#user-content-md045---images-should-have-alternate-text-alt-text) in the Markdown-based assets.