### PR TITLE
Require trust level >1 to create topics in tutorials category

### DIFF
--- a/content/categories/using-arduino/introductory-tutorials/README.md
+++ b/content/categories/using-arduino/introductory-tutorials/README.md
@@ -2,9 +2,12 @@
 
 ## Permissions
 
-| Group    | See | Reply | Create |
-| -------- | --- | ----- | ------ |
-| everyone | ✓   | ✓     | ✓      |
+| Group         | See | Reply | Create |
+| ------------- | --- | ----- | ------ |
+| everyone      | ✓   | ✓     |        |
+| trust_level_2 | ✓   | ✓     | ✓      |
+| trust_level_3 | ✓   | ✓     | ✓      |
+| trust_level_4 | ✓   | ✓     | ✓      |
 
 ## Published At
 

--- a/content/categories/using-arduino/introductory-tutorials/_pins.md
+++ b/content/categories/using-arduino/introductory-tutorials/_pins.md
@@ -1,7 +1,6 @@
 - https://forum.arduino.cc/t/flashing-multiple-leds-at-the-same-time/1065564
 - https://forum.arduino.cc/t/about-the-introductory-tutorials-category/847520
 - https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/681307
-- https://forum.arduino.cc/t/do-not-post-questions-in-this-part-of-the-forum/552462
 - https://forum.arduino.cc/t/getting-started-with-arduino-create-project-hub-web-editor-device-manager/537039
-- https://forum.arduino.cc/t/please-dont-post-your-questions-in-this-tutorial-section/496250
 - https://forum.arduino.cc/t/serial-input-basics-updated/382007
+- https://forum.arduino.cc/t/how-to-submit-a-tutorial/1111344

--- a/content/categories/using-arduino/introductory-tutorials/_topics/about-the-introductory-tutorials-category/1.md
+++ b/content/categories/using-arduino/introductory-tutorials/_topics/about-the-introductory-tutorials-category/1.md
@@ -1,2 +1,1 @@
 Tutorials for new people on the forum.
-**[color=#FF0000]Do not post your question in this forum section[/color]**

--- a/content/categories/using-arduino/introductory-tutorials/_topics/do-not-post-questions-in-this-part-of-the-forum/1.md
+++ b/content/categories/using-arduino/introductory-tutorials/_topics/do-not-post-questions-in-this-part-of-the-forum/1.md
@@ -1,2 +1,0 @@
-**[color=#FF0000]--- Please do not post your question in this part of the forum, it is for introductory tutorials, not for questions.
-Thank you. ---[/color]**

--- a/content/categories/using-arduino/introductory-tutorials/_topics/do-not-post-questions-in-this-part-of-the-forum/README.md
+++ b/content/categories/using-arduino/introductory-tutorials/_topics/do-not-post-questions-in-this-part-of-the-forum/README.md
@@ -1,5 +1,0 @@
-# --- Do not post questions in this part of the forum ---
-
-## Published At
-
-https://forum.arduino.cc/t/do-not-post-questions-in-this-part-of-the-forum/552462

--- a/content/categories/using-arduino/introductory-tutorials/_topics/how-to-submit-a-tutorial/1.md
+++ b/content/categories/using-arduino/introductory-tutorials/_topics/how-to-submit-a-tutorial/1.md
@@ -1,0 +1,16 @@
+This forum category contains a curated collection of tutorials.
+
+If you would like to propose the addition of a tutorial you wrote, follow these instructions:
+
+1. Publish your tutorial topic under a relevant normal forum category.
+1. The community may now make some suggestions for improvements. You can edit the tutorial contents by clicking the **🖉** icon at the bottom of the post.
+1. When the tutorial is ready to submit, click the "**🏴 Flag**" button at the bottom of the topic page.
+   A "**Thanks for helping to keep our community civil!**" dialog will open.
+1. Select the "**Something Else**" radio button in the dialog.
+1. Write a request for the moderators to move the topic to the tutorials category:
+   > I am proposing this tutorial be moved to the tutorials category.
+1. Click the "**✉ Message**" button in the dialog.
+
+The moderators will evaluate your tutorial and decide whether it is appropriate for inclusion in the curated tutorials.
+
+Thanks for your contribution!

--- a/content/categories/using-arduino/introductory-tutorials/_topics/how-to-submit-a-tutorial/README.md
+++ b/content/categories/using-arduino/introductory-tutorials/_topics/how-to-submit-a-tutorial/README.md
@@ -1,0 +1,5 @@
+# How to submit a tutorial
+
+## Published At
+
+https://forum.arduino.cc/t/how-to-submit-a-tutorial/1111344

--- a/content/categories/using-arduino/introductory-tutorials/_topics/please-dont-post-your-questions-in-this-tutorial-section/1.md
+++ b/content/categories/using-arduino/introductory-tutorials/_topics/please-dont-post-your-questions-in-this-tutorial-section/1.md
@@ -1,3 +1,0 @@
-**As subject.**
-**This section is for tutorials.**
-**(BTW, spammers - this is absolutely the best place to post your stuff)**

--- a/content/categories/using-arduino/introductory-tutorials/_topics/please-dont-post-your-questions-in-this-tutorial-section/README.md
+++ b/content/categories/using-arduino/introductory-tutorials/_topics/please-dont-post-your-questions-in-this-tutorial-section/README.md
@@ -1,5 +1,0 @@
-# PLEASE DON'T POST YOUR QUESTIONS IN THIS TUTORIAL SECTION
-
-## Published At
-
-https://forum.arduino.cc/t/please-dont-post-your-questions-in-this-tutorial-section/496250


### PR DESCRIPTION
Unlike the other categories where all relevant topics are welcome, [the tutorials forum category](https://forum.arduino.cc/c/using-arduino/introductory-tutorials/80) is a curated collection of high quality tutorials contributed by the forum community.

New users regularly create topics requesting assistance in this category. These make work for the forum maintainers who must move them to an appropriate category and make the category less useful as a source of tutorials.

The [**Discourse**](https://www.discourse.org/) forum framework used by Arduino Forum has [a user "trust level" system](https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/). As a user makes appropriate use of the forum, their trust level is automatically promoted and they gain more privileges.

In order to prevent miscategorized topics in this category, the configuration is changed to require a ["trust level" of 2](https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/#trust-level-2-member) or higher to directly create new topics in the tutorials category. Users with lower trust levels are still welcome to propose the addition of their tutorials. A pinned topic is added to the category with instructions for doing this.

Since the change to the configuration is expected to prevent miscategorized topics in the category, the existing topics warning against doing so are unpinned:

- https://forum.arduino.cc/t/do-not-post-questions-in-this-part-of-the-forum/552462
- https://forum.arduino.cc/t/please-dont-post-your-questions-in-this-tutorial-section/496250

---

Related discussion:

https://forum.arduino.cc/t/proposal-require-tl2-to-post-in-tutorials-category/1103022