### PR TITLE
Add "Using Arduino > Uncategorized" category

### DIFF
--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -3,6 +3,7 @@
     - Policies
   - TEST
 - Using Arduino
+  - Uncategorized
   - Installation & Troubleshooting
   - Introductory Tutorials
   - Avrdude, stk500, Bootloader issues

--- a/content/categories/using-arduino/uncategorized/README.md
+++ b/content/categories/using-arduino/uncategorized/README.md
@@ -1,0 +1,11 @@
+# Uncategorized
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
+## Published At
+
+https://forum.arduino.cc/c/using-arduino/uncategorized/184

--- a/content/categories/using-arduino/uncategorized/_pins.md
+++ b/content/categories/using-arduino/uncategorized/_pins.md
@@ -1,0 +1,3 @@
+- https://forum.arduino.cc/t/do-not-create-topics-in-this-category/1111650
+- https://forum.arduino.cc/t/about-the-uncategorized-category/1111646
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1111649

--- a/content/categories/using-arduino/uncategorized/_topics/about-the-uncategorized-category/1.md
+++ b/content/categories/using-arduino/uncategorized/_topics/about-the-uncategorized-category/1.md
@@ -1,0 +1,13 @@
+DO NOT USE! Please select the appropriate category for your topic.
+
+The sole purpose of this category is to help the forum maintainers to identify topics that were not correctly categorized by the author.
+
+When creating topics, please carefully select the category that is most appropriate for the subject matter. There is an "**About the \_\_\_\_\_ category**" topic at the top of each category that explains its purpose.
+
+To learn more about creating a forum topic, see the ["**How to get the best out of this forum**"](https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966#1-choose-the-right-category) guide.
+
+---
+
+⚠ Creation of topics in this category may result in suspension of your account. ⚠
+
+---

--- a/content/categories/using-arduino/uncategorized/_topics/about-the-uncategorized-category/README.md
+++ b/content/categories/using-arduino/uncategorized/_topics/about-the-uncategorized-category/README.md
@@ -1,0 +1,5 @@
+# About the Uncategorized category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-uncategorized-category/1111646

--- a/content/categories/using-arduino/uncategorized/_topics/do-not-create-topics-in-this-category/1.md
+++ b/content/categories/using-arduino/uncategorized/_topics/do-not-create-topics-in-this-category/1.md
@@ -1,0 +1,3 @@
+More information:
+
+https://forum.arduino.cc/t/about-the-uncategorized-category/1111646

--- a/content/categories/using-arduino/uncategorized/_topics/do-not-create-topics-in-this-category/README.md
+++ b/content/categories/using-arduino/uncategorized/_topics/do-not-create-topics-in-this-category/README.md
@@ -1,0 +1,5 @@
+# ⚠ DO NOT CREATE TOPICS IN THIS CATEGORY ⚠
+
+## Published At
+
+https://forum.arduino.cc/t/do-not-create-topics-in-this-category/1111650

--- a/content/categories/using-arduino/uncategorized/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/using-arduino/uncategorized/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../_topics/how-to-get-the-best-out-of-this-forum


### PR DESCRIPTION
It is common for new users to create topics in the [**Using Arduino > Installation & Troubleshooting**](https://forum.arduino.cc/c/using-arduino/installation-troubleshooting/18) category even though the subject matter of the topic is not in scope for the intended usage of that category.

The hypothesis is that one factor in these miscategorizations is that the category happens to be the first available one in the category listings and new users (and possibly spammers as well) are selecting it out of laziness instead of taking the time to select the most appropriate category.

The "Uncategorized" category is added in that problematic first writable category position to act as a dedicated collection point for these topics. The forum maintainers can periodically review the topics that are created there and clear out the category.

Since the fact that the category should not be used is clearly communicated to the user, creation of a topic there is a clear indication that the forum members should guide the user in [the responsible use of the forum](https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966).

The new category is added as a subcategory of the first top level category to avoid the creation of an additional top level category (which are very prominent on [the "**Categories**" page](https://forum.arduino.cc/categories)/default [home page](https://forum.arduino.cc/)).

---

Related discussion:

https://forum.arduino.cc/t/proposal-add-dedicated-category-to-catch-topics-created-in-first-category-arbitrarily/1110132