### PR TITLE
Update "Moderator Instructions" to reflect changes to forum UI

### DIFF
--- a/content/categories/staff/moderation/_topics/moderator-instructions/1.md
+++ b/content/categories/staff/moderation/_topics/moderator-instructions/1.md
@@ -67,7 +67,7 @@ Flags are shown on the ["Review" page](https://forum.arduino.cc/review). A moder
 
 ### [User-submitted flags](#user-submitted-flags)
 
-Users can flag any post by clicking the **⬤⬤⬤** icon, then the **:black_flag:**. Multiple flags result in the post being automatically hidden and eventually deleted, without any moderator action.
+Users can flag any post by clicking the **:black_flag:** icon. The post may be automatically locked and/or hidden pending review based on the number of flags and ["trust level"](https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/) of the flaggers.
 
 When submitting a flag, the user selects the category of the reason for the flag, which is shown on the ["Review" page](https://forum.arduino.cc/review).
 
@@ -77,10 +77,9 @@ When submitting a flag, the user selects the category of the reason for the flag
 
 The ["Review" page](https://forum.arduino.cc/review) presents four options for handling user-submitted flags:
 
-- **Agree...** - the flag was correct and the post was in violation of forum rules. The author of the flagged post will be [penalized](https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/).
-- **Disagree** - the flag was incorrect. The user who submitted the flag will be penalized.
-- **Ignore** - the flag was correct, but didn't indicate a problem with the flagged post. Nobody is penalized. If the post was automatically hidden by the flag, it will remain hidden.
-- **Delete...** - the flagged post should be deleted. The dropdown menu offers "**Delete Post and Ignore**" and "**Delete Post and Agree**" options, which have the effects on the author of the flagged post documented above.
+- **Yes ▾** - the flag was correct and the post was in violation of forum rules. The author of the flagged post will be [penalized](https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/).
+- **No** - the flag was incorrect. The user who submitted the flag will be penalized.
+- **Ignore ▾** - the flag was correct, but didn't indicate a problem with the flagged post. Nobody is penalized. If the post was automatically hidden by the flag, it will remain hidden.
 
 ---
 
@@ -108,15 +107,15 @@ See the [**"Inappropriate behavior"**](#deal-with-inappropriate-behavior) instru
 
 ##### [If the post is not spam](#if-the-post-is-not-spam)
 
-1. Click the **<kbd>:-1: Disagree</kbd>** button.
+1. Click the **<kbd>No</kbd>** button.
 
 <a name="if-the-post-is-spam"></a>
 
 ##### [If the post is spam](#if-the-post-is-spam)
 
-1. Click the **<kbd>:+1: Agree...</kbd>** button.
-1. From the dropdown menu, click **Suspend User**. The **"Suspend User"** dialog will open.
-1. From the **Select a timeframe** dropdown menu, select **Forever**.
+1. Click the **<kbd>Yes ▾</kbd>** button.
+1. From the dropdown menu, click **Suspend user**. The **"Suspend User"** dialog will open.
+1. From the **Suspend user until** dropdown menu, select **Forever**.
 1. In the **Suspension Reason** text field, enter "spam".
 1. From the **"What would you like to do with the associated post?"** dropdown menu, select **Delete the post**.
 1. Click the **<kbd>:no_entry_sign: Suspend</kbd>** button.
@@ -130,7 +129,7 @@ See the [**"Inappropriate behavior"**](#deal-with-inappropriate-behavior) instru
 The user submitting a "Something Else" flag will provide a message explaining the purpose of the flag. This might be used to flag problematic posts that don't fit into any of the standard user-submitted flag categories, or simply as an efficient means of communicating with the moderators about a benign post (e.g., requesting a tutorial topic be closed to discussion).
 
 1. [Review the flag](#review-flag).
-1. If the flag warranted action, resolve it, following the relevant instructions provided elsewhere in this document. In cases where an **"Agree"** review was warranted but you are unable to take the external action to resolve the flag, just select **"Keep Post"** from the **<kbd>:+1: Agree...</kbd>** menu. A message is generated in the [**"Moderators"** messages folder](https://forum.arduino.cc/my/messages/group/moderators) for each "Something Else" flag, and this message will be used to track the request.
+1. If the flag warranted action, resolve it, following the relevant instructions provided elsewhere in this document. In cases where an **"Yes"** review was warranted but you are unable to take the external action to resolve the flag, just select **"Keep post"** from the **<kbd>Yes ▾</kbd>** menu. A message is generated in the [**"Moderators"** messages folder](https://forum.arduino.cc/my/messages/group/moderators) for each "Something Else" flag, and this message will be used to track the request.
 1. A private message is generated for each "Something Else" flag. This can be accessed directly via the flag's **<kbd>view full conversation</kbd>** button, or the [**"Moderators"** messages folder](https://forum.arduino.cc/my/messages/group/moderators). If the flag was resolved by the review interface itself, this message will automatically be archived. However, it is often not possible to resolve the flag via the review interface (e.g., [moving](#move-topic-to-correct-category) a topic to the appropriate category). In this case, the message must be manually archived by clicking its **<kbd>:file_folder: Archive</kbd>** button.
 
    ![Archive message|356x500, 50%](https://europe1.discourse-cdn.com/arduino/original/4X/0/e/c/0ec0938faf6e77029655ff167701d3ca16bbdd3f.png)
@@ -199,14 +198,14 @@ This flag is created by `@system` when a post is detected as possibly spam by [A
 
 ##### [If the post is benign](#if-the-post-is-benign-1)
 
-1. Click the **<kbd>:-1: Not Spam</kbd>** button.
+1. Click the **<kbd>Not Spam</kbd>** button.
 
 <a name="if-the-post-is-malicious-1"></a>
 
 ##### [If the post is malicious](#if-the-post-is-malicious-1)
 
-1. Click the **<kbd>:+1: Agree...</kbd>** button.
-1. From the dropdown menu, select **Confirm Spam & Suspend User**.
+1. Click the **<kbd>Yes ▾</kbd>** button.
+1. From the dropdown menu, select **Suspend User**.
 
 ---
 
@@ -266,9 +265,9 @@ Mentions of relevant products or services of interest to the Arduino community a
 1. Click the **⬤⬤⬤** icon at the bottom of the spam post.
 1. Click the **:black_flag:** icon.
 1. Click the **It's Spam** radio button.
-1. Click the **<kbd>Take Action...</kbd>** button.
+1. Click the **<kbd>Take Action... ▾</kbd>** button.
 1. From the dropdown menu, click **Suspend User**. The **"Suspend User"** dialog will open.
-1. From the **Select a timeframe** dropdown menu, select **Forever**.
+1. From the **Suspend user until** dropdown menu, select **Forever**.
 1. In the **Suspension Reason** text field, enter "spam".
 1. From the **"What would you like to do with the associated post?"** dropdown menu, select **Delete the post**.
 1. Click the **<kbd>:no_entry_sign: Suspend</kbd>** button.
@@ -371,7 +370,7 @@ A topic hijack is when a user makes a reply that is not relevant to the topic. T
 
 ### [Reopen auto-closed topic](#reopen-auto-closed-topic)
 
-When four months have passed since the last reply to a topic, it is automatically closed and non-staff forum users are prevented from replying. Forum users may request topics be unlocked by raising a "Something Else" flag against the topic.
+When six months have passed since the last reply to a topic, it is automatically closed and non-staff forum users are prevented from replying. Forum users may request topics be unlocked by raising a "Something Else" flag against the topic.
 
 When a reopen request flag is received, it should be reviewed to determine whether reopening the topic would be appropriate.
 
@@ -387,8 +386,8 @@ When a reopen request flag is received, it should be reviewed to determine wheth
    > The topic has now been reopened.
 1. Click the <kbd>**:email: Message**</kbd> button.
 1. Go back to [the flag review page](https://forum.arduino.cc/review).
-1. Click the <kbd>**Ignore**</kbd> button on the flag message.
-   **Note:** the <kbd>**:+1: Agree...**</kbd> button should not be used because this would result in an unwarranted strike against the topic author.
+1. Click the <kbd>**Ignore ▾**</kbd> button on the flag message.
+   **Note:** the <kbd>**Yes ▾**</kbd> button should not be used because this would result in an unwarranted strike against the topic author.
 
 ##### If reopening is not appropriate
 
@@ -398,7 +397,7 @@ When a reopen request flag is received, it should be reviewed to determine wheth
    > We have decided to leave the topic closed. Please [create a new topic](https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966#first-post).
 1. Click the <kbd>**:email: Message**</kbd> button.
 1. Go back to [the flag review page](https://forum.arduino.cc/review).
-1. Click the <kbd>**:-1: Disagree**</kbd> button.
+1. Click the <kbd>**No**</kbd> button.
 
 ---
 
@@ -612,7 +611,7 @@ Account suspensions are used when the intention is to permanently exclude the us
 1. Open the user's profile page. This can be accessed by clicking their user name, then the user name in the profile preview popup.
 1. Click the **<kbd>Admin</kbd>** button.
 1. From the **Permissions** section, click the **<kbd>:no_entry_sign: Suspend</kbd>** button.
-1. From the **Select a timeframe** dropdown menu, select **Forever**.
+1. From the **Suspend user until** dropdown menu, select **Forever**.
 1. In the **Suspension Reason** text field, enter a short explanation for the cause of suspension (e.g., "spam").
 1. Click the **<kbd>:no_entry_sign: Suspend</kbd>** button.
 

--- a/content/categories/staff/moderation/_topics/moderator-instructions/1.md
+++ b/content/categories/staff/moderation/_topics/moderator-instructions/1.md
@@ -59,7 +59,7 @@ For an overview of the Discourse moderation system, see the **[Discourse Moderat
 
 Flags are used to bring things to the attention of the moderators. They may be submitted [by forum users](#user-submitted-flags) or [by automated systems](#automated-system-submitted-flags).
 
-Flags are shown on the ["Review" page](https://forum.arduino.cc/review). A moderators must review each flag and decide how it should be handled.
+Flags are shown on the ["Review" page](https://forum.arduino.cc/review). A moderator must review each flag and decide how it should be handled.
 
 **Note:** there are some conditions where mention of products or services is allowed and not considered spam, which are listed [here](#exceptions).
 
@@ -130,7 +130,7 @@ See the [**"Inappropriate behavior"**](#deal-with-inappropriate-behavior) instru
 The user submitting a "Something Else" flag will provide a message explaining the purpose of the flag. This might be used to flag problematic posts that don't fit into any of the standard user-submitted flag categories, or simply as an efficient means of communicating with the moderators about a benign post (e.g., requesting a tutorial topic be closed to discussion).
 
 1. [Review the flag](#review-flag).
-1. If the flag warranted action, resolve it, following the relevant instructions provided elsewhere in this document. In cases where an **"Agree"** review was warranted but you are unable to take the external action to resolve the flag, just select **"Keep Post"** from the **<kbd>:+1: Agree...</kbd>** menu. A message is generated in the [**"Moderators"** messages folder](https://forum.arduino.cc/my/messages/group/moderators) for each "Something Else" flag, and this message will be used to track the request. If the flag was resolved by the review process itself
+1. If the flag warranted action, resolve it, following the relevant instructions provided elsewhere in this document. In cases where an **"Agree"** review was warranted but you are unable to take the external action to resolve the flag, just select **"Keep Post"** from the **<kbd>:+1: Agree...</kbd>** menu. A message is generated in the [**"Moderators"** messages folder](https://forum.arduino.cc/my/messages/group/moderators) for each "Something Else" flag, and this message will be used to track the request.
 1. A private message is generated for each "Something Else" flag. This can be accessed directly via the flag's **<kbd>view full conversation</kbd>** button, or the [**"Moderators"** messages folder](https://forum.arduino.cc/my/messages/group/moderators). If the flag was resolved by the review interface itself, this message will automatically be archived. However, it is often not possible to resolve the flag via the review interface (e.g., [moving](#move-topic-to-correct-category) a topic to the appropriate category). In this case, the message must be manually archived by clicking its **<kbd>:file_folder: Archive</kbd>** button.
 
    ![Archive message|356x500, 50%](https://europe1.discourse-cdn.com/arduino/original/4X/0/e/c/0ec0938faf6e77029655ff167701d3ca16bbdd3f.png)


### PR DESCRIPTION
The "Moderator Instructions" post contains references to forum user interface components. Changes made to the design of the forum made some of these references outdated.

The instructions are here brought up to date for the current forum user interface.