### PR TITLE
Add instructions re: "flag_sockpuppets" flag to Moderator Instructions

### DIFF
--- a/.github/workflows/check-toc-task.yml
+++ b/.github/workflows/check-toc-task.yml
@@ -106,3 +106,15 @@ jobs:
         if: failure() && steps.check-toc.outcome == 'failure'
         run: |
           echo "::notice file=${{ matrix.file.name }}::Corrected file was saved to the ${{ env.ARTIFACT_NAME }} workflow artifact"
+
+      - name: Resolution instructions
+        if: failure() && steps.check-toc.outcome == 'failure'
+        run: |
+          echo "Table of contents can be updated by running the following command from the root of the repository:"
+          echo "task markdown:toc FILE_PATH=${{ matrix.file.name }} MAX_DEPTH=${{ matrix.file.maxdepth }}"
+          echo
+          echo "- OR -"
+          echo
+          echo "Download the ${{ env.ARTIFACT_NAME }} workflow artifact and replace ${{ matrix.file.name }} with the"
+          echo "corrected file from the artifact."
+          echo "See: https://docs.github.com/actions/managing-workflow-runs/downloading-workflow-artifacts"

--- a/.github/workflows/check-toc-task.yml
+++ b/.github/workflows/check-toc-task.yml
@@ -56,6 +56,9 @@ jobs:
     if: needs.run-determination.outputs.result == 'true'
     runs-on: ubuntu-latest
 
+    env:
+      ARTIFACT_NAME: corrected-files
+
     strategy:
       fail-fast: false
 
@@ -86,4 +89,20 @@ jobs:
             MAX_DEPTH=${{ matrix.file.maxdepth }}
 
       - name: Check ToC
+        id: check-toc
         run: git diff --color --exit-code
+
+      - name: Upload corrected file to workflow artifact
+        if: failure() && steps.check-toc.outcome == 'failure'
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          name: ${{ env.ARTIFACT_NAME }}
+          # Globstar prefix is to preserve folder structure in artifact.
+          # https://github.com/actions/upload-artifact/tree/v3.1.2#:~:text=path%20hierarchy%20will%20be%20preserved
+          path: "**/${{ matrix.file.name }}"
+
+      - name: Add artifact availability notice
+        if: failure() && steps.check-toc.outcome == 'failure'
+        run: |
+          echo "::notice file=${{ matrix.file.name }}::Corrected file was saved to the ${{ env.ARTIFACT_NAME }} workflow artifact"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,7 +20,6 @@ tasks:
       - task: general:correct-spelling
       - task: general:format-prettier
       - task: markdown:fix
-      - task: markdown:toc
 
   # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/check-workflows-task/Taskfile.yml
   ci:validate:

--- a/content/categories/staff/moderation/_topics/moderator-instructions/1.md
+++ b/content/categories/staff/moderation/_topics/moderator-instructions/1.md
@@ -23,6 +23,7 @@ For an overview of the Discourse moderation system, see the **[Discourse Moderat
     - ["Needs Approval" flag for account](#needs-approval-flag-for-account)
     - ["Needs Approval" flag for post](#needs-approval-flag-for-post)
     - [Akismet flagged post](#akismet-flagged-post)
+    - ["flag_sockpuppets" flag](#flag_sockpuppets-flag)
 - [Guides](#guides)
   - [Deal with inappropriate behavior](#deal-with-inappropriate-behavior)
   - [Delete spam](#delete-spam)
@@ -206,6 +207,37 @@ This flag is created by `@system` when a post is detected as possibly spam by [A
 
 1. Click the **<kbd>Yes ▾</kbd>** button.
 1. From the dropdown menu, select **Suspend User**.
+
+---
+
+<a name="sockpuppets-flag"></a>
+
+#### ["flag_sockpuppets" flag](#sockpuppets-flag)
+
+This flag is created by `@system` when a new user created a topic, and another new user at the same IP address replied. The flagged post must be reviewed by a moderator.
+
+---
+
+⚠ Legitimate users may happen to be assigned the same IP address. Be sure to carefully evaluate the flagged posts and user accounts before taking any administrative action.
+
+---
+
+<a name="if-the-post-is-benign-2"></a>
+
+##### [If the post is benign](#if-the-post-is-benign-2)
+
+1. Click the **<kbd>No, restore post</kbd>** button.
+
+<a name="if-the-post-is-malicious-2"></a>
+
+##### [If the post is malicious](#if-the-post-is-malicious-2)
+
+1. Click the **<kbd>Yes ▾</kbd>** button.
+1. From the dropdown menu, click **Suspend User**. The **"Suspend User"** dialog will open.
+1. From the **Select a timeframe** dropdown menu, select **Forever**.
+1. In the **Suspension Reason** text field, enter "malicious use of multiple accounts".
+1. From the **"What would you like to do with the associated post?"** dropdown menu, select **Delete the post**.
+1. Click the **<kbd>:no_entry_sign: Suspend</kbd>** button.
 
 ---
 


### PR DESCRIPTION
A new feature for automated identification of potentially malicious posts was recently enabled:

> If a new user replies to a topic from the same IP address as the user who started the topic, flag both of their posts as potential spam.

This system produces a new type of automated flag for the moderators to review but the moderator instructions don't mention it.

Flag review instructions are here added for this flag type alongside the existing instructions for other automated flags in the "**Moderator Instructions**" asset post:

https://github.com/arduino/forum-assets/commit/c675daa640185679f663fdef4f33f57caab9a890

---

I also made this repository's automated table of contents check more friendly to contributors who change relevant content, as done in this PR.

- https://github.com/arduino/forum-assets/commit/9d6b27e4fda66936c0d773646d4572370e62e046
- https://github.com/arduino/forum-assets/commit/76c4980d60f27c3f14da78ec8df859e8bd939840

---

Preview the updated content here: https://github.com/per1234/forum-assets/blob/sockpuppet-flag-instructions/content/categories/staff/moderation/_topics/moderator-instructions/1.md#readme

---

Related discussion:

- https://forum.arduino.cc/t/discussion-re-moderator-documentation-content/852461 (private)
- https://forum.arduino.cc/t/flag-sockpuppets-automated-flag-feature-enabled/1111193 (private)