### PR TITLE
Use Dependabot to manage all project dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,10 @@ updates:
       interval: daily
     labels:
       - "topic: infrastructure"
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,10 @@ updates:
       interval: daily
     labels:
       - "topic: infrastructure"
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   # Configure check for outdated GitHub Actions actions in workflows.
   # See: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-actions-up-to-date-with-dependabot
   - package-ecosystem: github-actions
+    assignees:
+      - per1234
     directory: / # Check the repository's workflows under /.github/workflows/
     schedule:
       interval: daily
@@ -12,6 +14,8 @@ updates:
       - "topic: infrastructure"
 
   - package-ecosystem: npm
+    assignees:
+      - per1234
     directory: /
     schedule:
       interval: daily
@@ -19,6 +23,8 @@ updates:
       - "topic: infrastructure"
 
   - package-ecosystem: pip
+    assignees:
+      - per1234
     directory: /
     schedule:
       interval: daily


### PR DESCRIPTION
The [**Dependabot**](https://docs.github.com/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) service is used to facilitate updates of project dependencies.

When a newer version of a dependency becomes available, Dependabot automatically submits a pull request to the repository. The continuous integration systems will then provide some automated validation  of the update, followed by evaluation by a maintainer.

Previously Dependabot was only configured to manage the [**GitHub Actions** action](https://docs.github.com/actions/learn-github-actions/understanding-github-actions#actions) dependencies of the project's continuous integration system. But Dependabot also supports other dependendency frameworks, including [**npm**](https://www.npmjs.com/) and [**pip**](https://pip.pypa.io/en/stable/) which are also used by this project.

Dependabot is here configured to also facilitate updates of the **npm** and **pip**-managed project dependencies.