### PR TITLE
Remove "Agree there is a problem" staff post template

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -165,9 +165,6 @@
       "pattern": "^https://forum\\.arduino\\.cc/t/moved-to-italian-section/1087955$"
     },
     {
-      "pattern": "^https://forum\\.arduino\\.cc/t/agree-there-is-a-problem/1087944$"
-    },
-    {
       "pattern": "^https://forum\\.arduino\\.cc/t/moved-to-german-section/1087953$"
     },
     {

--- a/content/categories/templates/_topics/agree-there-is-a-problem/1.md
+++ b/content/categories/templates/_topics/agree-there-is-a-problem/1.md
@@ -1,1 +1,0 @@
-Thanks for letting us know. We agree there is an issue and we're looking into it.

--- a/content/categories/templates/_topics/agree-there-is-a-problem/README.md
+++ b/content/categories/templates/_topics/agree-there-is-a-problem/README.md
@@ -1,5 +1,0 @@
-# Agree there is a problem
-
-## Published At
-
-https://forum.arduino.cc/t/agree-there-is-a-problem/1087944 (private)


### PR DESCRIPTION
A collection of precomposed replies for use in common moderation operations is provided to staff via the "**Insert template**" menu of the post composer:

https://meta.discourse.org/t/discourse-templates/229250

While the text of the "**Agree there is a problem**" template is appropriate when the forum software automatically adds it as a reply to the flag review thread after a moderator makes [a "Yes" review](https://meta.discourse.org/t/discourse-moderation-guide/63116#handling-flags-17), there isn't any common occasion where a staff member would need to manually create a reply with this text. So the template only clutters up the menu.

---

NOTE: the "**Agree there is a problem**" template removal has no effect on the automated flag review thread reply of the same text, which does not use the post template system.

---

Related discussion:

https://forum.arduino.cc/t/discussion-re-post-templates-content/856761 (private)