### PR TITLE
Remove "Code tags Usage" staff post template

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -129,9 +129,6 @@
       "pattern": "^https://forum\\.arduino\\.cc/t/getting-to-tl-so-you-can-post-images-etc/1087956$"
     },
     {
-      "pattern": "^https://forum\\.arduino\\.cc/t/code-tags-usage/1087949$"
-    },
-    {
       "pattern": "^https://forum\\.arduino\\.cc/t/moved/1087950$"
     },
     {

--- a/content/categories/templates/_topics/code-tags-usage/1.md
+++ b/content/categories/templates/_topics/code-tags-usage/1.md
@@ -1,8 +1,0 @@
-Thank you for posting your code but I am sure you can see that the formatting is a mess. The forum has something called 'code tags', which sort out the problems with the formatting. If you edit your code to include the code tags \<CODE/\>, the code will be easier to read and you will be more likely to get help.
-
-If you are unsure what to do please follow the advice given in the link below when posting code, there are instructions for using code tags, along with lots of other advice to help us to help you.
-https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966#posting-code
-
-If you get errors when compiling please copy them from the IDE using the "Copy error messages" button and paste the clipboard here in code tags
-
-Thank you.

--- a/content/categories/templates/_topics/code-tags-usage/README.md
+++ b/content/categories/templates/_topics/code-tags-usage/README.md
@@ -1,5 +1,0 @@
-# Code tags Usage
-
-## Published At
-
-https://forum.arduino.cc/t/code-tags-usage/1087949 (private)


### PR DESCRIPTION
A collection of precomposed replies for use in common moderation operations is provided to staff via the "**Insert template**" menu of the post composer.

https://meta.discourse.org/t/discourse-templates/229250

Replies for use in providing project support are out of scope for the templates since it is not feasible to develop and maintain such content as part of the forum assets.

Since it is out of scope, the "**Code tags Usage**" template should be removed.

---

Related discussion:

https://forum.arduino.cc/t/discussion-re-post-templates-content/856761 (private)