### PR TITLE
Add note re: availability of "staging site" forum to "About the TEST category" post

### DIFF
--- a/content/categories/staff/test/_topics/about-the-test-category/1.md
+++ b/content/categories/staff/test/_topics/about-the-test-category/1.md
@@ -1,3 +1,11 @@
 A sandbox in which Arduino Forum staff can experiment freely. Expect strange and nonsensical content.
 
 DO NOT post anything of value or that you want others to pay attention to in this category.
+
+---
+
+**ⓘ** An isolated "sandbox" forum instance is also available. The "staging site" forum can be used for more involved testing and experimentation without any risk of affecting the production forum users.
+
+Instructions for accessing the "staging site" forum are [**here**](https://forum.arduino.cc/t/staging-site-sandbox-forum-instance/1112538).
+
+---


### PR DESCRIPTION
While the "TEST" category is a convenient place for staff to make simple tests and experiments, it is insufficient for some things. In this case, the dedicated sandbox forum instance can be used for freely running tests and experiments on any aspect of the forum.

For this reason, it will be helpful to bring the existence of the "staging site" forum to the attention of the users of the TEST forum. This is done by adding a note to the "About the TEST category" post, which links to instructions in a topic dedicated to the subject.

---

Preview of rendered content:

https://github.com/per1234/forum-assets/blob/document-staging-site-in-test-category/content/categories/staff/test/_topics/about-the-test-category/1.md#readme

---

Published at:

https://forum.arduino.cc/t/about-the-test-category/847511 (private)