### PR TITLE
Add "staging site" forum access instructions link to "Moderator Instructions" asset docs

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -102,6 +102,9 @@
       "pattern": "^https://forum\\.arduino\\.cc/t/moderation-guidelines/54905$"
     },
     {
+      "pattern": "^https://forum\\.arduino\\.cc/t/staging-site-sandbox-forum-instance/1112538$"
+    },
+    {
       "pattern": "^https://forum\\.arduino\\.cc/t/this-forum-section-will-be-in-read-only/376698$"
     },
     {

--- a/content/categories/staff/moderation/_topics/moderator-instructions/README.md
+++ b/content/categories/staff/moderation/_topics/moderator-instructions/README.md
@@ -15,3 +15,5 @@
 - https://forum.arduino.cc/t/draft-proposal-for-moderator-documentation/623114 (private)
 - https://meta.discourse.org/t/discourse-moderation-guide/63116
 - https://forum.arduino.cc/t/about-user-account-deletion-and-user-content-deletion/627095 (private)
+- ["Staging site" sandbox forum access instructions](https://forum.arduino.cc/t/staging-site-sandbox-forum-instance/1112538) (private)
+  - This can be used for testing during the development of standard moderation procedures.


### PR DESCRIPTION
The "**Moderator Instructions**" asset post contains a detailed instructions for each of the standard moderation procedures.

The procedures must be tested during the development and maintenance of the content. The "staging site" sandbox forum instance is useful for this purpose; allowing the performance of the procedures freely without any risk of affecting the production forum.

For this reason, it will be helpful to bring the existence of the "staging site" forum to the attention of those doing development and maintenance of the "**Moderator Instructions**" content. This is accomplished by adding a link to a topic dedicated to the subject in the "**Related**" section of the "Moderator Instructions" asset's documentation.

---

Preview of rendered content:

https://github.com/per1234/forum-assets/blob/moderator-instructions-docs-staging-site-link/content/categories/staff/moderation/_topics/moderator-instructions/README.md#related

---

The linked topic:

https://forum.arduino.cc/t/staging-site-sandbox-forum-instance/1112538 (private)

---

Related discussion:

https://forum.arduino.cc/t/discussion-re-moderator-documentation-content/852461 (private)