### PR TITLE
Improve wording of "Moved to Spanish section" post template

### DIFF
--- a/content/categories/templates/_topics/moved-to-spanish-section/1.md
+++ b/content/categories/templates/_topics/moved-to-spanish-section/1.md
@@ -1,5 +1,5 @@
 :warning:
 
-Tu publicación fue **MOVIDA** a su ubicación actual ya que es más adecuada.
+He trasladado su tema de una categoría de idioma inglés del foro a la categoría **International > Español** <!-- TODO: @username -->.
 
 ¿Podría también tomarse unos minutos para [Aprenda a usar el foro](https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966)?

--- a/content/categories/templates/_topics/moved-to-spanish-section/1.md
+++ b/content/categories/templates/_topics/moved-to-spanish-section/1.md
@@ -1,5 +1,4 @@
 :warning:
-Código corregido
 
 Tu publicación fue **MOVIDA** a su ubicación actual ya que es más adecuada.
 

--- a/content/categories/templates/_topics/moved-to-spanish-section/1.md
+++ b/content/categories/templates/_topics/moved-to-spanish-section/1.md
@@ -2,6 +2,7 @@
 
 He trasladado su tema de una categoría de idioma inglés del foro a la categoría **International > Español** <!-- TODO: @username -->.
 
-En adelante por favor usar la categoría apropiada a la lengua en que queráis publicar. ¿Podría también tomarse unos minutos para [Aprenda a usar el foro](https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966)?
+En adelante por favor usar la categoría apropiada a la lengua en que queráis publicar. Esto es importante para el uso responsable del foro, y esta explicado aquí [la guía "**How to get the best out of this forum**"](https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966).
+Este guía contiene mucha información útil. Por favor leer.
 
 De antemano, muchas gracias por cooperar.

--- a/content/categories/templates/_topics/moved-to-spanish-section/1.md
+++ b/content/categories/templates/_topics/moved-to-spanish-section/1.md
@@ -2,4 +2,6 @@
 
 He trasladado su tema de una categoría de idioma inglés del foro a la categoría **International > Español** <!-- TODO: @username -->.
 
-¿Podría también tomarse unos minutos para [Aprenda a usar el foro](https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966)?
+En adelante por favor usar la categoría apropiada a la lengua en que queráis publicar. ¿Podría también tomarse unos minutos para [Aprenda a usar el foro](https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966)?
+
+De antemano, muchas gracias por cooperar.


### PR DESCRIPTION
A collection of precomposed replies for use in standard moderation operations is provided to staff via the "**Insert template**" menu of the post composer:

https://meta.discourse.org/t/discourse-templates/229250

This includes the reply to be used by a moderator after moving a Spanish-language topic out of an English language category.

Some minor adjustments to the wording and formatting are made here with the following goals:

- Improve the tone
- More clearly communicate about the recategorization action
- More clearly communicate about the expected behavior modification
- Highlight the request to read the user guide

See the individual commit messages for more details:

https://github.com/arduino/forum-assets/pull/375/commits

The text was translated by a native Spanish speaker

---

Diff for proposed changes:

https://github.com/arduino/forum-assets/pull/375/files

---

Preview of rendered content:

https://github.com/per1234/forum-assets/blob/update-moved-to-spanish-section-template/content/categories/templates/_topics/moved-to-spanish-section/1.md#readme

---

Related discussion:

https://forum.arduino.cc/t/discussion-re-post-templates-content/856761 (private)