### PR TITLE
Update Arduino Science Journal App reference link

### DIFF
--- a/content/categories/hardware/arduino-education-kits/arduino-science-journal-arduino-science-kit/_topics/about-the-arduino-science-journal-arduino-science-kit-category/1.md
+++ b/content/categories/hardware/arduino-education-kits/arduino-science-journal-arduino-science-kit/_topics/about-the-arduino-science-journal-arduino-science-kit-category/1.md
@@ -4,6 +4,6 @@ Empower students to think and act like real scientists by bringing an inquiry-ba
 
 Quick resources check:
 
-- Science Journal app: [sj.arduino.cc](https://sj.arduino.cc)
+- Science Journal app: <https://www.arduino.cc/education/science-journal>
 - Science Kit: [https://www.arduino.cc/education/science-kit](https://www.arduino.cc/education/science-kit)
 - Help Center section: [Science Journal app troubleshooting](https://support.arduino.cc/hc/en-us/sections/360004584459-Science-Journal-App)


### PR DESCRIPTION
The previous link currently produces a 503 response. That may be a temporary situation, but during my investigation I discovered that the previous link has been a redirect for some time now. Experience shows that these redirects have a tendency to break or change to leading to content other than what was intended (e.g., to the arduino.cc home page). So even if the redirect may eventually be fixed, it is better to update the link to point directly to the intended content rather than relying on the redirect.