### PR TITLE
Add "Nano ESP32" category

### DIFF
--- a/content/categories/hardware/nano-family/nano-esp32/README.md
+++ b/content/categories/hardware/nano-family/nano-esp32/README.md
@@ -1,0 +1,11 @@
+# Nano ESP32
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
+## Published At
+
+https://forum.arduino.cc/c/hardware/nano-family/nano-esp32/190

--- a/content/categories/hardware/nano-family/nano-esp32/_pins.md
+++ b/content/categories/hardware/nano-family/nano-esp32/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-nano-esp32-category/1151125
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1151127

--- a/content/categories/hardware/nano-family/nano-esp32/_topics/about-the-nano-esp32-category/1.md
+++ b/content/categories/hardware/nano-family/nano-esp32/_topics/about-the-nano-esp32-category/1.md
@@ -1,0 +1,3 @@
+Discussion about the Nano ESP32 board.
+
+The Nano ESP32 is based on the Espressif ESP32 microcontroller.

--- a/content/categories/hardware/nano-family/nano-esp32/_topics/about-the-nano-esp32-category/README.md
+++ b/content/categories/hardware/nano-family/nano-esp32/_topics/about-the-nano-esp32-category/README.md
@@ -1,0 +1,5 @@
+# About the Nano ESP32 category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-nano-esp32-category/1151125

--- a/content/categories/hardware/nano-family/nano-esp32/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/hardware/nano-family/nano-esp32/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -44,6 +44,7 @@
   - Nano Family
     - Classic Nano
     - Nano 33 IoT
+    - Nano ESP32
     - Nano Every
     - Nano 33 BLE
     - Nano 33 BLE Sense


### PR DESCRIPTION
This is the dedicated product category for the new [Arduino Nano ESP32 board](https://docs.arduino.cc/hardware/nano-esp32).