### PR TITLE
Adjust wording of "Moved to French section" content template for clarity

### DIFF
--- a/content/categories/templates/_topics/moved-to-french-section/1.md
+++ b/content/categories/templates/_topics/moved-to-french-section/1.md
@@ -1,4 +1,4 @@
 :warning:
-Post mis dans la mauvaise section, on parle anglais dans les forums généraux. ➜ déplacé vers le forum francophone.
+Post mis dans la mauvaise section, on parle anglais dans les forums généraux, je viens de déplacer le post dans la section francophone.
 
 Merci de prendre en compte les recommandations listées dans "[Les bonnes pratiques du Forum Francophone](https://forum.arduino.cc/t/les-bonnes-pratiques-du-forum-francophone/861014)".


### PR DESCRIPTION
Forum member [**al1fch**](https://forum.arduino.cc/u/al1fch) contributed this adjustment to the wording of the [template](https://meta.discourse.org/t/discourse-templates/229250):

> The original message is 100% correct but now days some confusion is growing about 'participe passé' so it's useful to adopt another way to say that action (deplacement) has been done.