### PR TITLE
Configure link checker tool to ignore Chrome App link

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -18,6 +18,9 @@
       "pattern": "^https://cloud\\.arduino\\.cc/cloud$"
     },
     {
+      "pattern": "^https://chromewebstore\\.google\\.com/detail/arduino-create-for-educat/elmgohdonjdampbcgefphnlchgocpaij$"
+    },
+    {
       "pattern": "^https://forum\\.arduino\\.cc/c/community/workshops-and-events/events-and-tour/"
     },
     {

--- a/content/categories/software/chrome-app/_topics/about-the-chrome-app-category/1.md
+++ b/content/categories/software/chrome-app/_topics/about-the-chrome-app-category/1.md
@@ -1,3 +1,3 @@
-The [Arduino Create Chrome App for Education](https://chrome.google.com/webstore/detail/arduino-create-for-educat/elmgohdonjdampbcgefphnlchgocpaij) allows students to write code and upload sketches to official Arduino boards.
+The [Arduino Create Chrome App for Education](https://chromewebstore.google.com/detail/arduino-create-for-educat/elmgohdonjdampbcgefphnlchgocpaij) allows students to write code and upload sketches to official Arduino boards.
 
 Arduino Create is hosted online, therefore it will always be up-to-date with the latest features and support for new boards. Students' sketchbooks are saved on the cloud, always backed up and accessible from any device.


### PR DESCRIPTION
The [**markdown-link-check**](https://github.com/tcort/markdown-link-check) tool is used to detect broken links in the project's Markdown files.

The tool is detecting the link to the Arduino Create Chrome App page in the Chrome Web Store as broken:

https://github.com/arduino/forum-assets/actions/runs/8152896140/job/22283222021#step:5:28

```text
  ERROR: 1 dead links found in ./content/categories/software/chrome-app/_topics/about-the-chrome-app-category/1.md !
  [✖] https://chrome.google.com/webstore/detail/arduino-create-for-educat/elmgohdonjdampbcgefphnlchgocpaij → Status: 0
```

However, when the link is visited by a human it works as expected. This spurious failure is avoided by adding that URL to [the tool's ignore list](https://github.com/tcort/markdown-link-check#config-file-format).