### PR TITLE
Remove "Create" permission for TL2 in "Introductory Tutorials" category

### DIFF
--- a/content/categories/using-arduino/introductory-tutorials/README.md
+++ b/content/categories/using-arduino/introductory-tutorials/README.md
@@ -5,7 +5,6 @@
 | Group         | See | Reply | Create |
 | ------------- | --- | ----- | ------ |
 | everyone      | ✓   | ✓     |        |
-| trust_level_2 | ✓   | ✓     | ✓      |
 | trust_level_3 | ✓   | ✓     | ✓      |
 | trust_level_4 | ✓   | ✓     | ✓      |
 


### PR DESCRIPTION
"Introductory Tutorials" is a curated category. The permissions are configured so that only users with a higher "["trust level"](https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/)" with the forum software can create topics in the category. Users with lower trust levels can submit tutorials via [the procedure](https://forum.arduino.cc/t/how-to-submit-a-tutorial/1111344) documented in a pinned topic.

Prior to the establishment of the trust level-based restrictions, anyone could create topics in the category. The bulk of the inappropriate categories came from new users with trust level 0 or 1. So the [permissions were configured to require a trust level of 2 or higher in order to directly create a topic](https://forum.arduino.cc/t/proposal-require-tl2-to-post-in-tutorials-category/1103022).

The TL>=2 configuration was effective in achieving the intended result of preventing blatantly miscategorized topics. However, [doubts were raised](https://forum.arduino.cc/t/tutorials-quality-checks/1240280) about whether some of the topics created directly (bypassing the evaluation procedure) in the category since that time meet the standards for inclusion. Although a user should be past the stage of blatant miscategorization by the time they have enough forum activity to earn trust level 2, it can be attained quite quickly and so some TL2 users might not have gained a good enough understanding of the mores of the community in order to make the correct decision unilaterally regarding whether their topic is appropriate for inclusion in the "Introductory Tutorials" category. For this reason, the category permissions are adjusted so that the minimum trust level for directly creating topics in the category is now 3. TL3 takes a very significant amount of engagement in the forum. As before, any user at any trust level is still welcome to submit tutorials.