### PR TITLE
Unpin Software > IoT Cloud's "Examples" topic

### DIFF
--- a/content/categories/software/iot-cloud/_pins.md
+++ b/content/categories/software/iot-cloud/_pins.md
@@ -1,3 +1,2 @@
 - https://forum.arduino.cc/t/gallery-of-iot-projects-share-yours/1101609
 - https://forum.arduino.cc/t/about-the-iot-cloud-category/847592
-- https://forum.arduino.cc/t/examples/550317


### PR DESCRIPTION
I evaluated the topic and found it was completely obsolete:

* The single provided example won't compile.
* The link to the "Arduno IoT Cloud Getting Started" Project Hub project is broken.

So this topic no longer qualifies to be pinned.