### PR TITLE
Add template for responding to flag on post making responsible use of AI-generated content

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -87,6 +87,9 @@
       "pattern": "^https://forum\\.arduino\\.cc/t/about-the-windows-virtual-shields-for-arduino-category/847513$"
     },
     {
+      "pattern": "^https://forum\\.arduino\\.cc/t/flag-for-post-making-responsible-use-of-ai-generated-content/1289013$"
+    },
+    {
       "pattern": "^https://forum\\.arduino\\.cc/t/hi-welcome-to-maker-faire-rome-the-european-edition/158299$"
     },
     {

--- a/content/categories/templates/_topics/flag-for-post-making-responsible-use-of-ai-generated-content/1.md
+++ b/content/categories/templates/_topics/flag-for-post-making-responsible-use-of-ai-generated-content/1.md
@@ -1,0 +1,9 @@
+Thanks for taking the time to report this.
+
+I did a brief review of the post and found that the information they are sharing appears to be relevant and accurate. It is perfectly fine for people to post AI-generated content on the forum as long as they have verified the information.
+
+Posting irrelevant or inaccurate AI-generated content due to cursorily copy and pasting without doing verification is irresponsible and something the moderators will take action to stop. So if you identify such posts, please do flag it. If the problem with the post wouldn't be obvious to someone who doesn't have special expertise in that subject matter, please select the "**Something Else**" option from the flag creation dialog and provide a description of the problem in the message field that appears in the dialog.
+
+Otherwise valid AI-generated content is frequently used as a vehicle for hiding spam links, so it is worth giving special scrutiny to such content. Please do flag any posts you see that contain spammy looking links.
+
+I didn't see any signs of malicious intent in this specific case though, so I have determined that no moderation is needed.

--- a/content/categories/templates/_topics/flag-for-post-making-responsible-use-of-ai-generated-content/README.md
+++ b/content/categories/templates/_topics/flag-for-post-making-responsible-use-of-ai-generated-content/README.md
@@ -1,0 +1,5 @@
+# Flag for Post Making Responsible Use of AI-Generated Content
+
+## Published At
+
+https://forum.arduino.cc/t/flag-for-post-making-responsible-use-of-ai-generated-content/1289013 (private)


### PR DESCRIPTION
Although posting of AI-generated content for malicious purposes, or without responsible verification is not allowed (just the same as with non-AI content), responsible use of AI-generated content [is allowed](https://forum.arduino.cc/t/proposed-change-to-the-forum-guide-chatgpt/1113934/9) (just the same as with non-AI content).

Forum users sometimes raise flags solely due to a post containing AI-generated content, even though it was used responsibly. When the moderator declines the flag, it may be useful to make a response to explain the decision. This template will allow doing so effectively and efficiently.