### PR TITLE
Add moderator instructions for "Illegal" flags

### DIFF
--- a/content/categories/staff/moderation/_topics/moderator-instructions/1.md
+++ b/content/categories/staff/moderation/_topics/moderator-instructions/1.md
@@ -18,6 +18,7 @@ For an overview of the Discourse moderation system, see the "[**Discourse Modera
     - [Post flagged as "Off-Topic"](#post-flagged-as-off-topic)
     - [Post flagged as "Inappropriate"](#post-flagged-as-inappropriate)
     - [Post flagged as "Spam"](#post-flagged-as-spam)
+    - [Post flagged as "Illegal"](#post-flagged-as-illegal)
     - [Post flagged as "Something Else"](#post-flagged-as-something-else)
   - [Automated system-submitted flags](#automated-system-submitted-flags)
     - ["Needs Approval" flag for account](#needs-approval-flag-for-account)
@@ -128,6 +129,38 @@ See the ["**Inappropriate behavior**" instructions](#deal-with-inappropriate-beh
 1. In the "**Suspension Reason**" text field, enter `spam`.
 1. From the "**What would you like to do with the associated post?**" dropdown menu, select "**Delete the post**".
 1. Click the <kbd>**🛇 Suspend**</kbd> button.
+
+---
+
+<a name="post-flagged-as-illegal"></a>
+
+#### [Post flagged as "Illegal"](#post-flagged-as-illegal)
+
+##### Procedure for moderators
+
+---
+
+❗ These flags require action by the forum manager so moderators must leave the flag open in the review queue in order to allow the forum manager to effectively track their tasks.
+
+---
+
+1. _Do not_ click any of the buttons in the flag review interface.
+1. Perform appropriate moderation of the flagged post and poster account, as usual.
+
+##### Procedure for forum manager
+
+1. Send notification of report via the channel specified in [the DSA policy document](https://arduino.cc/en/digital-services-act):
+
+   ```text
+   A user has flagged an Arduino Forum post as containing illegal content:
+
+   <!-- TODO: link to flag -->
+   ```
+
+   - ❗ A notification must be sent for all "**Illegal**" flags, regardless of merit.
+   - **ⓘ** The link to the flag is available from the timestamp at the top of the review queue item.
+
+1. [Review the flag](#review-flag).
 
 ---
 


### PR DESCRIPTION
The Moderator Instructions document defines the standard procedures moderators follow to handle flags raised on posts. When a user raises a flag, they select from a list of general reasons for flagging. The Moderator Instructions document provides a procedure for each of these flag types.

Since the time the Moderator Instructions document was written, the [**Discourse** forum framework](https://www.discourse.org/about) added a new "Illegal" reason to the flag dialog:

https://meta.discourse.org/t/new-its-illegal-reason-when-flagging-posts/294866

A procedure for handling this flag type is hereby added.