### PR TITLE
Add information to "FAQ/Guidelines" re: alternative illegal content reporting channel

### DIFF
--- a/content/categories/staff/_topics/faq-guidelines/1.md
+++ b/content/categories/staff/_topics/faq-guidelines/1.md
@@ -45,7 +45,7 @@ Let’s leave our community better than we found it.
 
 Moderators have special authority; they are responsible for this forum. But so are you. With your help, moderators can be community facilitators, not just janitors or police.
 
-When you see bad behavior, don’t reply. It encourages the bad behavior by acknowledging it, consumes your energy, and wastes everyone’s time. _Just flag it_. If enough flags accrue, action will be taken, either automatically or by moderator intervention.
+When you see bad behavior, don’t reply. It encourages the bad behavior by acknowledging it, consumes your energy, and wastes everyone’s time. [_Just flag it_](https://meta.discourse.org/t/flag-a-post-for-moderator-attention/32783). If enough flags accrue, action will be taken, either automatically or by moderator intervention.
 
 In order to maintain our community, moderators reserve the right to remove any content and any user account for any reason at any time. Moderators do not preview new posts; the moderators and site operators take no responsibility for any content posted by the community.
 

--- a/content/categories/staff/_topics/faq-guidelines/1.md
+++ b/content/categories/staff/_topics/faq-guidelines/1.md
@@ -49,6 +49,16 @@ When you see bad behavior, don’t reply. It encourages the bad behavior by ackn
 
 In order to maintain our community, moderators reserve the right to remove any content and any user account for any reason at any time. Moderators do not preview new posts; the moderators and site operators take no responsibility for any content posted by the community.
 
+<a name="illegal-content"></a>
+
+### [Illegal Content](#illegal-content)
+
+If you see illegal content on **Arduino Forum**, [flag](https://meta.discourse.org/t/flag-a-post-for-moderator-attention/32783) the post and select "**It's Illegal**" from the list of reasons for flagging in the dialog that appears.
+
+If you don't have an **Arduino Forum** account, you can report illegal content here:
+
+https://report-content.arduino.cc/
+
 <a name="be-civil"></a>
 
 ## [Always Be Civil](#be-civil)

--- a/content/categories/staff/_topics/faq-guidelines/README.md
+++ b/content/categories/staff/_topics/faq-guidelines/README.md
@@ -23,3 +23,4 @@ The stock document is provided as part of the Discourse instance and is not Ardu
 - Page as rendered to users: https://forum.arduino.cc/faq
 - https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966
 - https://meta.discourse.org/t/discourse-new-user-guide/96331
+- Upstream source: https://github.com/discourse/discourse/blob/main/config/locales/server.en.yml (in the `en.guidelines_topic` mapping)


### PR DESCRIPTION
This information will allow illegal content to be reported by those who don't have an Arduino Forum account.