### PR TITLE
Add note to "Moderator Instructions" re: "Change post ownership" being admin-only

### DIFF
--- a/content/categories/staff/moderation/_topics/moderator-instructions/1.md
+++ b/content/categories/staff/moderation/_topics/moderator-instructions/1.md
@@ -751,6 +751,12 @@ Account suspensions are used when the intention is to permanently exclude the us
 
 ### [Change post ownership](#change-post-ownership)
 
+---
+
+❗ The forum framework only allows administrators to change post ownership, so this procedure can not be used by moderators.
+
+---
+
 1. Click the **⬤⬤⬤** icon at the bottom of the post to be transferred.
 1. Click the wrench icon.
    A menu will open.


### PR DESCRIPTION
It turns out that the Discourse forum framework doesn't bestow this power on moderators.

Administrators also perform moderation so the instructions are still in scope for this document, but it will be useful to note that fact in the instructions to avoid confusion.