### PR TITLE
Add "Conserve the Conversation" section to FAQ/Guidelines asset topic

### DIFF
--- a/content/categories/staff/_topics/faq-guidelines/1.md
+++ b/content/categories/staff/_topics/faq-guidelines/1.md
@@ -94,6 +94,20 @@ Rather than posting “+1” or “Agreed”, use the Like button. Rather than t
 
 You may not post anything digital that belongs to someone else without permission. You may not post descriptions of, links to, or methods for stealing someone’s intellectual property (software, video, audio, images), or for breaking any other law.
 
+<a name="conserve-the-conversation"></a>
+
+## [Conserve the Conversation](#conserve-the-conversation]
+
+The posts in a forum topic provide the context for the replies that follow. It is fine to make trivial edits to your posts, but significant edits or deletion would diminish the efforts of the other participants in the conversation by causing the loss of meaning of their contributions.
+
+When you need to add information, or make a correction to something you wrote in a previous post which has already become part of the discussion, do that by adding a new reply to the topic instead of by editing or deleting your previous post.
+
+<a name="anonymization"></a>
+
+### [Anonymization](#anonymization)
+
+If you decide you no longer wish your username to be associated with posts you made, we will be happy to anonymize them. Just send a request to [privacy@arduino.cc](mailto:privacy@arduino.cc).
+
 <a name="power"></a>
 
 ## [Powered by You](#power)


### PR DESCRIPTION
A common problem on the forum is newcomers causing confusion and frustration by editing or deleting their posts after others have replied to them.

This is typically not done out of any malicious intentions so it will be useful to explain that it is not appropriate, and why, in the forum Guidelines.

One of the common reasons for users later deleting a post is that they wish to reduce their "digital footprint". In this case, the correct solution will be to request the anonymization of the post rather than deleting it. So a dedicated subsection is added to address this subject.