### PR TITLE
Pull improvements to FAQ/Guidelines from upstream

### DIFF
--- a/content/categories/staff/_topics/faq-guidelines/1.md
+++ b/content/categories/staff/_topics/faq-guidelines/1.md
@@ -4,30 +4,30 @@
 
 Please treat this discussion forum with the same respect you would a public park. We, too, are a shared community resource &mdash; a place to share skills, knowledge and interests through ongoing conversation.
 
-These are not hard and fast rules, merely guidelines to aid the human judgment of our community and keep this a clean and well-lighted place for civilized public discourse.
+These are not hard and fast rules. They are guidelines to aid the human judgment of our community and keep this a kind, friendly place for civilized public discourse.
 
 <a name="improve"></a>
 
 ## [Improve the Discussion](#improve)
 
-Help us make this a great place for discussion by always working to improve the discussion in some way, however small. If you are not sure your post adds to the conversation, think over what you want to say and try again later.
-
-The topics discussed here matter to us, and we want you to act as if they matter to you, too. Be respectful of the topics and the people discussing them, even if you disagree with some of what is being said.
+Help us make this a great place for discussion by always adding something positive to the discussion, however small. If you are not sure your post adds to the conversation, think over what you want to say and try again later.
 
 One way to improve the discussion is by discovering ones that are already happening. Spend time browsing the topics here before replying or starting your own, and you’ll have a better chance of meeting others who share your interests.
+
+The topics discussed here matter to us, and we want you to act as if they matter to you, too. Be respectful of the topics and the people discussing them, even if you disagree with some of what is being said.
 
 <a name="agreeable"></a>
 
 ## [Be Agreeable, Even When You Disagree](#agreeable)
 
-You may wish to respond to something by disagreeing with it. That’s fine. But remember to _criticize ideas, not people_. Please avoid:
+You may wish to respond by disagreeing. That’s fine. But remember to _criticize ideas, not people_. Please avoid:
 
 - Name-calling
 - Ad hominem attacks
 - Responding to a post’s tone instead of its actual content
 - Knee-jerk contradiction
 
-Instead, provide reasoned counter-arguments that improve the conversation.
+Instead, provide thoughtful insights that improve the conversation.
 
 <a name="participate"></a>
 
@@ -35,7 +35,7 @@ Instead, provide reasoned counter-arguments that improve the conversation.
 
 The conversations we have here set the tone for every new arrival. Help us influence the future of this community by choosing to engage in discussions that make this forum an interesting place to be &mdash; and avoiding those that do not.
 
-Discourse provides tools that enable the community to collectively identify the best (and worst) contributions: bookmarks, likes, flags, replies, edits, and so forth. Use these tools to improve your own experience, and everyone else’s, too.
+Discourse provides tools that enable the community to collectively identify the best (and worst) contributions: bookmarks, likes, flags, replies, edits, watching, muting and so forth. Use these tools to improve your own experience, and everyone else’s, too.
 
 Let’s leave our community better than we found it.
 
@@ -45,7 +45,7 @@ Let’s leave our community better than we found it.
 
 Moderators have special authority; they are responsible for this forum. But so are you. With your help, moderators can be community facilitators, not just janitors or police.
 
-When you see bad behavior, don’t reply. It encourages the bad behavior by acknowledging it, consumes your energy, and wastes everyone’s time. [_Just flag it_](https://meta.discourse.org/t/flag-a-post-for-moderator-attention/32783). If enough flags accrue, action will be taken, either automatically or by moderator intervention.
+When you see bad behavior, don’t reply. Replying encourages bad behavior by acknowledging it, consumes your energy, and wastes everyone’s time. [_Just flag it_](https://meta.discourse.org/t/flag-a-post-for-moderator-attention/32783). If enough flags accrue, action will be taken, either automatically or by moderator intervention.
 
 In order to maintain our community, moderators reserve the right to remove any content and any user account for any reason at any time. Moderators do not preview new posts; the moderators and site operators take no responsibility for any content posted by the community.
 
@@ -70,7 +70,7 @@ Nothing sabotages a healthy conversation like rudeness:
 - Respect each other. Don’t harass or grief anyone, impersonate people, or expose their private information.
 - Respect our forum. Don’t post spam or otherwise vandalize the forum.
 
-These are not concrete terms with precise definitions &mdash; avoid even the _appearance_ of any of these things. If you’re unsure, ask yourself how you would feel if your post was featured on the front page of the New York Times.
+These are not concrete terms with precise definitions &mdash; avoid even the _appearance_ of any of these things. If you’re unsure, ask yourself how you would feel if your post was featured on the front page of a major news site.
 
 This is a public forum, and search engines index these discussions. Keep the language, links, and images safe for family and friends.
 
@@ -80,7 +80,7 @@ This is a public forum, and search engines index these discussions. Keep the lan
 
 Make the effort to put things in the right place, so that we can spend more time discussing and less cleaning up. So:
 
-- Don’t start a topic in the wrong category.
+- Don’t start a topic in the wrong category; please read the category definitions.
 - Don’t cross-post the same thing in multiple topics.
 - Don’t post no-content replies.
 - Don’t divert a topic by changing it midstream.
@@ -112,7 +112,7 @@ If you decide you no longer wish your username to be associated with posts you m
 
 ## [Powered by You](#power)
 
-This site is operated by your [friendly local staff](/about) and _you_, the community. If you have any further questions about how things should work here, open a new topic in the [site feedback category](/c/community/website-and-forum/40) and let's discuss! If there's a critical or urgent issue that can't be handled by a meta topic or flag, contact us via the [staff page](/about).
+This site is operated by your [friendly moderator team](/about) and _you_, the community. If you have any further questions about how things should work here, open a new topic in the ["**Website and Forum**" category](/c/community/website-and-forum/40) and let's discuss! If there's a critical or urgent issue that can't be handled by a meta topic or flag, [contact the moderators](/about).
 
 <a name="tos"></a>
 


### PR DESCRIPTION
The "FAQ/Guidelines" post is based on [a stock post provided by the Discourse forum framework](https://github.com/discourse/discourse/blob/main/config/locales/server.en.yml).

Since the time the post was created on Arduino Forum, various minor improvements have been made to the upstream post by the Discourse community. Those improvements are hereby pulled into the Arduino Forum post content.