### PR TITLE
Add post asset source comments to "Moderator Instructions" post

### DIFF
--- a/content/categories/staff/moderation/_topics/moderator-instructions/1.md
+++ b/content/categories/staff/moderation/_topics/moderator-instructions/1.md
@@ -180,6 +180,8 @@ The user submitting a "**Something Else**" flag will provide a message explainin
    In cases where an "**Yes**" review was warranted but you are unable to take the external action to resolve the flag, just select "**Keep post**" from the <kbd>**Yes ▾**</kbd> menu. A message is generated in the ["**Moderators**" messages folder](https://forum.arduino.cc/my/messages/group/moderators) for each "**Something Else**" flag, and this message will be used to track the request.
 1. A private message is generated for each "**Something Else**" flag. This can be accessed directly via the flag's <kbd>**view full conversation**</kbd> button, or the ["**Moderators**" messages folder](https://forum.arduino.cc/my/messages/group/moderators). If the flag was resolved by the review interface itself, this message will automatically be archived. However, it is often not possible to resolve the flag via the review interface (e.g., [moving](#move-topic-to-correct-category) a topic to the appropriate category). In this case, the message must be manually archived by clicking its <kbd>**🗀 Archive**</kbd> button.
 
+   <!-- Source: https://github.com/arduino/forum-assets/blob/main/content/categories/staff/moderation/_topics/moderator-instructions/_assets/archive-something-else-flag-message.png -->
+
    ![Archive message|356x500, 50%](https://europe1.discourse-cdn.com/arduino/original/4X/0/e/c/0ec0938faf6e77029655ff167701d3ca16bbdd3f.png)
 
    ⚠ The ["**Moderators**" messages folder](https://forum.arduino.cc/my/messages/group/moderators) is shared between all the moderators. When you take an action it affects the inbox for everyone.
@@ -500,6 +502,8 @@ Deletion requests are often an ["XY problem"](https://wikipedia.org/wiki/XY_prob
 
 This chart provides an overview of the workflow:
 
+<!-- Source: https://github.com/arduino/forum-assets/blob/main/content/categories/staff/moderation/_topics/moderator-instructions/_assets/content-deletion-handling-overview.mmd -->
+
 ![content-deletion-handling-overview|227x500](upload://xCkOx3T4FX7dQwQHz4s8T5AK9Ns.png)
 
 #### Redirect content deletion
@@ -509,6 +513,8 @@ A variety of distinct goals may lay behind a content deletion request. Each goal
 ##### Closure
 
 The goal behind the request is the user does not want further discussion in their topic.
+
+<!-- Source: https://github.com/arduino/forum-assets/blob/main/content/categories/staff/moderation/_topics/moderator-instructions/_assets/redirect-content-deletion-closure.mmd -->
 
 ![redirect-content-deletion-closure|204x500, 75%](upload://8sUHXjXuN2pwiSjPXhsXrJxEgQi.png)
 
@@ -521,6 +527,8 @@ The goal behind the request is to avoid the association of the content with the 
 Do not take any further action. Leave further handling and review of the flag to the forum manager. The reason for this is the per-post anonymization procedure that will be used to accomplish the user's privacy goal is only possible with administrative privileges.
 
 ###### Procedure for forum manager
+
+<!-- Source: https://github.com/arduino/forum-assets/blob/main/content/categories/staff/moderation/_topics/moderator-instructions/_assets/redirect-content-deletion-privacy.mmd -->
 
 ![redirect-content-deletion-privacy|239x500, 75%](upload://86H9keHIpqS4RIgyKt7KuVpiyqo.png)
 
@@ -536,11 +544,15 @@ Do not take any further action. Leave further handling and review of the flag to
 
 The user believes that they should delete the content because the topic is resolved and they didn't consider that it can be valuable to others.
 
+<!-- Source: https://github.com/arduino/forum-assets/blob/main/content/categories/staff/moderation/_topics/moderator-instructions/_assets/redirect-content-deletion-resolved.mmd -->
+
 ![redirect-content-deletion-resolved|339x500, 75%](upload://Y1DwJNHfslREmAFdI8Q0SjvOKe.png)
 
 ##### Tidy
 
 The goal behind the request is that the user has no more need for the content and they didn't consider that it can be valuable to others.
+
+<!-- Source: https://github.com/arduino/forum-assets/blob/main/content/categories/staff/moderation/_topics/moderator-instructions/_assets/redirect-content-deletion-tidy.mmd -->
 
 ![redirect-content-deletion-tidy|278x460, 65%](upload://55iWUSlRCnrH7q5FEKSDC7Jgatc.png)
 
@@ -562,17 +574,25 @@ Users often create topics in [categories](https://forum.arduino.cc/categories) w
 
 1. Click the pencil icon ("edit the title and category of this topic") to the right of the topic title.
 
+   <!-- Source: https://github.com/arduino/forum-assets/blob/main/content/categories/staff/moderation/_topics/moderator-instructions/_assets/edit-topic-title-category.png -->
+
    ![Edit topic title and category|487x253, 50%](https://europe1.discourse-cdn.com/arduino/original/4X/9/b/b/9bbf52090269d52f96c6957c6ba9b06ca6d72070.png)
 
 1. Click the category field, which is under the topic title field.
+
+   <!-- Source: https://github.com/arduino/forum-assets/blob/main/content/categories/staff/moderation/_topics/moderator-instructions/_assets/category-field.png -->
 
    ![Category field|487x297, 50%](https://europe1.discourse-cdn.com/arduino/original/4X/f/9/7/f975537c87ac67779c7dc8299bf09212e2ace7b6.png)
 
 1. Select the appropriate category from the dropdown menu. There is a convenient search feature to allow quickly finding the category you want.
 
+   <!-- Source: https://github.com/arduino/forum-assets/blob/main/content/categories/staff/moderation/_topics/moderator-instructions/_assets/category-menu.png -->
+
    ![Category menu|486x296, 50%](https://europe1.discourse-cdn.com/arduino/original/4X/8/f/b/8fba956e157d958952d7b6142fefda546e5d5aef.png)
 
 1. Click the <kbd>**✓**</kbd> button.
+
+   <!-- Source: https://github.com/arduino/forum-assets/blob/main/content/categories/staff/moderation/_topics/moderator-instructions/_assets/confirm-title-category.png -->
 
    ![Confirm category|486x331, 50%](https://europe1.discourse-cdn.com/arduino/original/4X/6/a/3/6a3a4f46600a335da2ec90659ce94c42a2e520dc.png)
 


### PR DESCRIPTION
The "Moderator Instructions" post is illustrated with several graphics and diagrams.

The image files of the published post are hosted on the forum server, and so it is those URLs that are referenced in the image embedding markup. However, the source files for those assets are hosted in the arduino/forum-assets GitHub repository, and it is these files that should be worked with for any updates of the post.

Previously there was no indication in the post content of the source of its assets, and thus a contributor might not be aware or their existence, or where to find them. This is resolved by adding adjacent comments to the post content with links to the location of each of the asset source files.