### PR TITLE
Control Python version used by "Check Category Order Metadata" workflow

### DIFF
--- a/.github/workflows/check-order-metadata-task.yml
+++ b/.github/workflows/check-order-metadata-task.yml
@@ -54,6 +54,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: pyproject.toml
+
       - name: Install Poetry
         run: |
           pipx install \


### PR DESCRIPTION
Previously, the workflow would use whichever version of Python was installed on the GitHub Actions runner machine. This meant that an update to the runner environment could break the workflow at any time.

The "actions/setup-python" action is now used to install the project's standardized version of Python, as specified by the pyproject.toml metadata file.