### PR TITLE
Update category slugs in URLs

### DIFF
--- a/content/categories/development-tools/ide-1-x/README.md
+++ b/content/categories/development-tools/ide-1-x/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/using-arduino/ide-1-x/18
+https://forum.arduino.cc/c/development-tools/ide-1-x/18

--- a/content/categories/development-tools/uploading/README.md
+++ b/content/categories/development-tools/uploading/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/using-arduino/uploading/81
+https://forum.arduino.cc/c/development-tools/uploading/81

--- a/content/categories/other-hardware/audio/README.md
+++ b/content/categories/other-hardware/audio/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/using-arduino/audio/24
+https://forum.arduino.cc/c/other-hardware/audio/24

--- a/content/categories/other-hardware/device-hacking/README.md
+++ b/content/categories/other-hardware/device-hacking/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/projects/device-hacking/33
+https://forum.arduino.cc/c/other-hardware/device-hacking/33

--- a/content/categories/other-hardware/displays/README.md
+++ b/content/categories/other-hardware/displays/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/using-arduino/displays/23
+https://forum.arduino.cc/c/other-hardware/displays/23

--- a/content/categories/other-hardware/e-textiles-and-craft/README.md
+++ b/content/categories/other-hardware/e-textiles-and-craft/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/projects/e-textiles-and-craft/29
+https://forum.arduino.cc/c/other-hardware/e-textiles-and-craft/29

--- a/content/categories/other-hardware/general-electronics/README.md
+++ b/content/categories/other-hardware/general-electronics/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/using-arduino/general-electronics/21
+https://forum.arduino.cc/c/other-hardware/general-electronics/21

--- a/content/categories/other-hardware/home-automation/README.md
+++ b/content/categories/other-hardware/home-automation/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/projects/home-automation/32
+https://forum.arduino.cc/c/other-hardware/home-automation/32

--- a/content/categories/other-hardware/interactive-art/README.md
+++ b/content/categories/other-hardware/interactive-art/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/projects/interactive-art/35
+https://forum.arduino.cc/c/other-hardware/interactive-art/35

--- a/content/categories/other-hardware/leds-and-multiplexing/README.md
+++ b/content/categories/other-hardware/leds-and-multiplexing/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/using-arduino/leds-and-multiplexing/22
+https://forum.arduino.cc/c/other-hardware/leds-and-multiplexing/22

--- a/content/categories/other-hardware/microcontrollers/README.md
+++ b/content/categories/other-hardware/microcontrollers/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/using-arduino/microcontrollers/59
+https://forum.arduino.cc/c/other-hardware/microcontrollers/59

--- a/content/categories/other-hardware/motors-mechanics-power-and-cnc/README.md
+++ b/content/categories/other-hardware/motors-mechanics-power-and-cnc/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/using-arduino/motors-mechanics-power-and-cnc/25
+https://forum.arduino.cc/c/other-hardware/motors-mechanics-power-and-cnc/25

--- a/content/categories/other-hardware/product-design/README.md
+++ b/content/categories/other-hardware/product-design/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/projects/product-design/36
+https://forum.arduino.cc/c/other-hardware/product-design/36

--- a/content/categories/other-hardware/robotics/README.md
+++ b/content/categories/other-hardware/robotics/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/projects/robotics/30
+https://forum.arduino.cc/c/other-hardware/robotics/30

--- a/content/categories/other-hardware/science-and-measurement/README.md
+++ b/content/categories/other-hardware/science-and-measurement/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/projects/science-and-measurement/31
+https://forum.arduino.cc/c/other-hardware/science-and-measurement/31

--- a/content/categories/other-hardware/sensors/README.md
+++ b/content/categories/other-hardware/sensors/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/using-arduino/sensors/26
+https://forum.arduino.cc/c/other-hardware/sensors/26

--- a/content/categories/other-hardware/storage/README.md
+++ b/content/categories/other-hardware/storage/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/using-arduino/storage/58
+https://forum.arduino.cc/c/other-hardware/storage/58

--- a/content/categories/projects-discussion-and-showcase/README.md
+++ b/content/categories/projects-discussion-and-showcase/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/projects/7
+https://forum.arduino.cc/c/projects-discussion-and-showcase/7

--- a/content/categories/projects-discussion-and-showcase/covid-19-projects/README.md
+++ b/content/categories/projects-discussion-and-showcase/covid-19-projects/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/projects/covid-19-projects/88
+https://forum.arduino.cc/c/projects-discussion-and-showcase/covid-19-projects/88

--- a/content/categories/projects-discussion-and-showcase/education-and-teaching/README.md
+++ b/content/categories/projects-discussion-and-showcase/education-and-teaching/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/projects/education-and-teaching/34
+https://forum.arduino.cc/c/projects-discussion-and-showcase/education-and-teaching/34

--- a/content/categories/projects-discussion-and-showcase/remote-learning/README.md
+++ b/content/categories/projects-discussion-and-showcase/remote-learning/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/projects/remote-learning/90
+https://forum.arduino.cc/c/projects-discussion-and-showcase/remote-learning/90


### PR DESCRIPTION
Some of the forum categories were renamed. The subcategories have the slug of the parent category in their URL. Some of these slugs were not updated at the time of the category renaming.

The slug component of the URL is completely ignored by the forum software, with the ID component being the only technically relevant part. So the link check did not catch these missed updates.