### PR TITLE
Correct title of "About the Projects category" asset topic documentation

### DIFF
--- a/content/categories/projects/_topics/about-the-using-arduino-category/README.md
+++ b/content/categories/projects/_topics/about-the-using-arduino-category/README.md
@@ -1,4 +1,4 @@
-# About the Using Arduino category
+# About the Projects category
 
 ## Published At
 


### PR DESCRIPTION
The title of this documentation page was not updated at the time the topic was renamed from "About the Using Arduino category".