### PR TITLE
Correct order metadata for "Workshops and Events" category

### DIFF
--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -110,9 +110,6 @@
   - Website and Forum
   - Products and Services
   - Jobs and Paid Consultancy
-  - Workshops and Events
-    - Makers
-    - Events and Tour
   - Groups and Events
   - Showcase
   - Bar Sport
@@ -176,4 +173,7 @@
     - Forum
     - Playground Wiki
   - India
+  - Workshops and Events
+    - Makers
+    - Events and Tour
 - Templates


### PR DESCRIPTION
The metadata was not updated at the time the category was moved to a different position in the categories list (https://github.com/arduino/forum-assets/pull/503).