### PR TITLE
Remove leftover duplicate entry in category order metadata

### DIFF
--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -131,7 +131,6 @@
     - Tutoriels et cours
     - Réalisations et Projets Finis
     - Le bar
-  - India
   - Italiano
     - Generale
     - Hardware


### PR DESCRIPTION
When the "India" category was moved to a different location in the categories list, a new entry was added at the new location, but the entry at the former location was not removed from the metadata file.