### PR TITLE
Lock the "Other Hardware" category

### DIFF
--- a/content/categories/other-hardware/README.md
+++ b/content/categories/other-hardware/README.md
@@ -4,7 +4,7 @@
 
 | Group    | See | Reply | Create |
 | -------- | --- | ----- | ------ |
-| everyone | ✓   | ✓     | ✓      |
+| everyone | ✓   |       |        |
 
 ## Published At
 

--- a/content/categories/other-hardware/_pins.md
+++ b/content/categories/other-hardware/_pins.md
@@ -1,2 +1,1 @@
 - https://forum.arduino.cc/t/about-the-other-hardware-category/1334654
-- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1334881

--- a/content/categories/other-hardware/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/other-hardware/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,1 +1,0 @@
-../../../_topics/how-to-get-the-best-out-of-this-forum


### PR DESCRIPTION
This category is only intended to be used as a container for subcategories. So creation of topics in the root of the category must be prohibited.