### PR TITLE
Rename "Education and Teaching" category to "Education"

### DIFF
--- a/content/categories/community/education-and-teaching/README.md
+++ b/content/categories/community/education-and-teaching/README.md
@@ -1,4 +1,4 @@
-# Education and Teaching
+# Education
 
 ## Permissions
 
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/community/education-and-teaching/34
+https://forum.arduino.cc/c/community/education/34

--- a/content/categories/community/education-and-teaching/_pins.md
+++ b/content/categories/community/education-and-teaching/_pins.md
@@ -1,2 +1,2 @@
-- https://forum.arduino.cc/t/about-the-education-and-teaching-category/847474
+- https://forum.arduino.cc/t/about-the-education-category/847474
 - https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/681327

--- a/content/categories/community/education-and-teaching/_topics/about-the-education-and-teaching-category/README.md
+++ b/content/categories/community/education-and-teaching/_topics/about-the-education-and-teaching-category/README.md
@@ -1,5 +1,5 @@
-# About the Education and Teaching category
+# About the Education category
 
 ## Published At
 
-https://forum.arduino.cc/t/about-the-education-and-teaching-category/847474
+https://forum.arduino.cc/t/about-the-education-category/847474

--- a/content/categories/forum-2005-2010-read-only/remote-learning/_topics/about-the-emergency-response-remote-learning-category/1.md
+++ b/content/categories/forum-2005-2010-read-only/remote-learning/_topics/about-the-emergency-response-remote-learning-category/1.md
@@ -1,3 +1,3 @@
-This category has been merged with "Education and Teaching"
+This category has been merged with "Education"
 
-Please use the #projects-discussion-and-showcase:education-and-teaching category for discussion of subjects related to education.
+Please use the #community:education category for discussion of subjects related to education.

--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -105,7 +105,7 @@
 - Community
   - General Discussion
   - Website and Forum
-  - Education and Teaching
+  - Education
   - Products and Services
   - Jobs and Paid Consultancy
   - Groups and Events


### PR DESCRIPTION
The "and Teaching" in the category name was completely superfluous. Excessive verbosity in category names is harmful because it makes it more likely the name will be truncated in category listings in the forum UI.