### PR TITLE
Make "Development Tools" first category in public listings

### DIFF
--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -1,6 +1,20 @@
 - Staff
   - Moderation
   - TEST
+- Development Tools
+  - IDE 2.x
+  - IDE 1.x
+  - Uploading
+  - Web Editor
+  - Cloud
+  - IoT Cloud
+  - Chrome App
+  - Intel®-based platforms
+  - Arduino command line tools
+  - Arduino SIM
+  - PLC IDE
+  - Windows Remote Arduino
+  - Windows Virtual Shields for Arduino
 - Projects
   - Uncategorized
   - Tutorials
@@ -88,20 +102,6 @@
   - Product Design
   - Robotics
   - Science and Measurement
-- Development Tools
-  - IDE 2.x
-  - IDE 1.x
-  - Uploading
-  - Web Editor
-  - Cloud
-  - IoT Cloud
-  - Chrome App
-  - Intel®-based platforms
-  - Arduino command line tools
-  - Arduino SIM
-  - PLC IDE
-  - Windows Remote Arduino
-  - Windows Virtual Shields for Arduino
 - Community
   - General Discussion
   - Website and Forum


### PR DESCRIPTION
The original category structure placed "Installation and Troubleshooting" (later renamed "IDE 1.x") as the first publicly visible category. There is logic in that order in that it reflects the user journey, where they must install and start the development tool before they can begin work on their project.