### PR TITLE
Use logical ordering for "Community" subcategories

### DIFF
--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -107,12 +107,12 @@
   - Website and Forum
   - Suggestions for the Arduino Project
   - Education
-  - Products and Services
-  - Jobs and Paid Consultancy
-  - Groups and Events
   - Showcase
-  - Bar Sport
   - Project Hub
+  - Groups and Events
+  - Bar Sport
+  - Jobs and Paid Consultancy
+  - Products and Services
 - International
   - 中文 (Chinese)
   - Deutsch


### PR DESCRIPTION
Previously, the listing of the "Community" category's subcategories had a somewhat random ordering.

The order is hereby adjusted to be more logical, by descending interest/significance.