### PR TITLE
Update category slugs in URLs

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -21,10 +21,10 @@
       "pattern": "^https://chromewebstore\\.google\\.com/detail/arduino-create-for-educat/elmgohdonjdampbcgefphnlchgocpaij$"
     },
     {
-      "pattern": "^https://forum\\.arduino\\.cc/c/community/workshops-and-events/events-and-tour/"
+      "pattern": "^https://forum\\.arduino\\.cc/c/forum-2005-2010-read-only/workshops-and-events/events-and-tour/"
     },
     {
-      "pattern": "^https://forum\\.arduino\\.cc/c/community/workshops-and-events/makers/"
+      "pattern": "^https://forum\\.arduino\\.cc/c/forum-2005-2010-read-only/workshops-and-events/makers/"
     },
     {
       "pattern": "^https://forum\\.arduino\\.cc/c/official-hardware/mkr-boards/mkr1000-old/"

--- a/content/categories/forum-2005-2010-read-only/india/README.md
+++ b/content/categories/forum-2005-2010-read-only/india/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/international/india/62
+https://forum.arduino.cc/c/forum-2005-2010-read-only/india/62

--- a/content/categories/forum-2005-2010-read-only/workshops-and-events/README.md
+++ b/content/categories/forum-2005-2010-read-only/workshops-and-events/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/community/workshops-and-events/43
+https://forum.arduino.cc/c/forum-2005-2010-read-only/workshops-and-events/43

--- a/content/categories/forum-2005-2010-read-only/workshops-and-events/events-and-tour/README.md
+++ b/content/categories/forum-2005-2010-read-only/workshops-and-events/events-and-tour/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/community/workshops-and-events/events-and-tour/68 (private)
+https://forum.arduino.cc/c/forum-2005-2010-read-only/workshops-and-events/events-and-tour/68 (private)

--- a/content/categories/forum-2005-2010-read-only/workshops-and-events/makers/README.md
+++ b/content/categories/forum-2005-2010-read-only/workshops-and-events/makers/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/community/workshops-and-events/makers/67 (private)
+https://forum.arduino.cc/c/forum-2005-2010-read-only/workshops-and-events/makers/67 (private)

--- a/content/categories/official-hardware/portenta-family/edge-control/README.md
+++ b/content/categories/official-hardware/portenta-family/edge-control/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/official-hardware/portenta/edge-control/178
+https://forum.arduino.cc/c/official-hardware/portenta-family/edge-control/178

--- a/content/categories/projects/covid-19-projects/README.md
+++ b/content/categories/projects/covid-19-projects/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/projects-discussion-and-showcase/covid-19-projects/88
+https://forum.arduino.cc/c/projects/covid-19-projects/88


### PR DESCRIPTION
Some of the forum categories were renamed. The subcategories have the slug of the parent category in their URL. Some of these slugs were not updated at the time of the category renaming.

The slug component of the URL is completely ignored by the forum software, with the ID component being the only technically relevant part. So the link check did not catch these missed updates.