### PR TITLE
Add "Classic" product class category

### DIFF
--- a/content/categories/official-hardware/classic/README.md
+++ b/content/categories/official-hardware/classic/README.md
@@ -1,0 +1,11 @@
+# Classic
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/classic/197

--- a/content/categories/official-hardware/classic/_pins.md
+++ b/content/categories/official-hardware/classic/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-classic-category/1335250
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1335251

--- a/content/categories/official-hardware/classic/_topics/about-the-classic-category/1.md
+++ b/content/categories/official-hardware/classic/_topics/about-the-classic-category/1.md
@@ -1,0 +1,1 @@
+The foundational Arduino hardware products

--- a/content/categories/official-hardware/classic/_topics/about-the-classic-category/README.md
+++ b/content/categories/official-hardware/classic/_topics/about-the-classic-category/README.md
@@ -1,0 +1,5 @@
+# About the Classic category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-classic-category/1335250

--- a/content/categories/official-hardware/classic/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/classic/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -57,6 +57,7 @@
     - Mkr1000 [old]
     - MKRWAN1310
     - MKR SHIELDS
+  - Classic
   - Arduino Yún
     - Yún Shield
   - Arduino WiFi Rev2


### PR DESCRIPTION
The subcategories of the "Official Hardware" category are to be organized under a subcategory for each of the product classes. These product classes are defined by the hardware documentation home page.

That hardware documentation places the foundational Arduino boards under a class named "Classic", so a forum category of this name is added