### PR TITLE
Add "Mega" product class category

### DIFF
--- a/content/categories/official-hardware/mega/README.md
+++ b/content/categories/official-hardware/mega/README.md
@@ -1,0 +1,11 @@
+# Mega
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/mega/198

--- a/content/categories/official-hardware/mega/_pins.md
+++ b/content/categories/official-hardware/mega/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-mega-category/1335266
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1335267

--- a/content/categories/official-hardware/mega/_topics/about-the-mega-category/1.md
+++ b/content/categories/official-hardware/mega/_topics/about-the-mega-category/1.md
@@ -1,0 +1,3 @@
+Hardware products in the "Mega" form factor
+
+The "Mega" form factor provides a large number of pins and is compatible with shields of the "UNO" form factor.

--- a/content/categories/official-hardware/mega/_topics/about-the-mega-category/README.md
+++ b/content/categories/official-hardware/mega/_topics/about-the-mega-category/README.md
@@ -1,0 +1,5 @@
+# About the Mega category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-mega-category/1335266

--- a/content/categories/official-hardware/mega/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/mega/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -45,6 +45,7 @@
     - Nano 33 BLE
     - Nano 33 BLE Sense
     - Nano RP2040 Connect
+  - Mega
   - MKR Family
     - MKRVIDOR4000
     - MKR1000


### PR DESCRIPTION
The subcategories of the "Official Hardware" category are to be organized under a subcategory for each of the product classes. These product classes are defined by the hardware documentation home page.

That hardware documentation places the boards of the "Mega" form factor under a class named "Classic", so a forum category of this name is added.