### PR TITLE
Add "Pro Solutions" product class category

### DIFF
--- a/content/categories/official-hardware/pro-solutions/README.md
+++ b/content/categories/official-hardware/pro-solutions/README.md
@@ -1,0 +1,11 @@
+# Mega
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/pro-solutions/199

--- a/content/categories/official-hardware/pro-solutions/_pins.md
+++ b/content/categories/official-hardware/pro-solutions/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-pro-solutions-category/1335283
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1335284

--- a/content/categories/official-hardware/pro-solutions/_topics/about-the-pro-solutions-category/1.md
+++ b/content/categories/official-hardware/pro-solutions/_topics/about-the-pro-solutions-category/1.md
@@ -1,0 +1,1 @@
+The "PRO Solutions" line of products from Arduino

--- a/content/categories/official-hardware/pro-solutions/_topics/about-the-pro-solutions-category/README.md
+++ b/content/categories/official-hardware/pro-solutions/_topics/about-the-pro-solutions-category/README.md
@@ -1,0 +1,5 @@
+# About the Pro Solutions category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-pro-solutions-category/1335283

--- a/content/categories/official-hardware/pro-solutions/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/pro-solutions/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -73,6 +73,7 @@
     - Arduino Starter Kit Classroom Pack
     - CTC GO!
     - Arduino Science Journal & Arduino Science Kit
+  - Pro Solutions
   - The Arduino Starter Kit
   - Arduino 101
   - Arduino Esplora


### PR DESCRIPTION
The subcategories of the "Official Hardware" category are to be organized under a subcategory for each of the product classes. These product classes are defined by the hardware documentation home page.

That hardware documentation places some products under a class named "Pro Solutions", so a forum category of this name is added.