### PR TITLE
Add "Retired" product class category

### DIFF
--- a/content/categories/official-hardware/retired/README.md
+++ b/content/categories/official-hardware/retired/README.md
@@ -1,0 +1,11 @@
+# Retired
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/retired/200

--- a/content/categories/official-hardware/retired/_pins.md
+++ b/content/categories/official-hardware/retired/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-retired-category/1335295
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1335296

--- a/content/categories/official-hardware/retired/_topics/about-the-retired-category/1.md
+++ b/content/categories/official-hardware/retired/_topics/about-the-retired-category/1.md
@@ -1,0 +1,1 @@
+Arduino products that have been retired

--- a/content/categories/official-hardware/retired/_topics/about-the-retired-category/README.md
+++ b/content/categories/official-hardware/retired/_topics/about-the-retired-category/README.md
@@ -1,0 +1,5 @@
+# About the Retired category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-retired-category/1335295

--- a/content/categories/official-hardware/retired/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/retired/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -86,6 +86,7 @@
     - Nicla Vision
     - Nicla Voice
   - Opta
+  - Retired
   - Yún Shield
 - Other Hardware
   - 3rd Party Boards


### PR DESCRIPTION
The subcategories of the "Official Hardware" category are to be organized under a subcategory for each of the product classes.

However, this classification is not done for hardware products which are no longer manufactured. A "Retired" category will be used as the container for the existing categories for retired products.