### PR TITLE
Add "Kits" product class category

### DIFF
--- a/content/categories/official-hardware/kits/README.md
+++ b/content/categories/official-hardware/kits/README.md
@@ -1,0 +1,11 @@
+# Kits
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/kits/201

--- a/content/categories/official-hardware/kits/_pins.md
+++ b/content/categories/official-hardware/kits/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-kits-category/1335302
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1335305

--- a/content/categories/official-hardware/kits/_topics/about-the-kits-category/1.md
+++ b/content/categories/official-hardware/kits/_topics/about-the-kits-category/1.md
@@ -1,0 +1,1 @@
+Hardware kits from Arduino

--- a/content/categories/official-hardware/kits/_topics/about-the-kits-category/README.md
+++ b/content/categories/official-hardware/kits/_topics/about-the-kits-category/README.md
@@ -1,0 +1,5 @@
+# About the Kits category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-kits-category/1335302

--- a/content/categories/official-hardware/kits/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/kits/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -25,6 +25,7 @@
   - Libraries
   - Emergency Response: Covid-19 Projects
 - Official Hardware
+  - Kits
   - Portenta Family
     - Portenta C33
     - Portenta H7


### PR DESCRIPTION
The subcategories of the "Official Hardware" category are to be organized under a subcategory for each of the product classes. These product classes are defined by the hardware documentation home page.

That hardware documentation places the hardware kits manufactured by Arduino for the "maker" marked under a class named "Kits", so a forum category of this name is added.