### PR TITLE
Replace placeholders for Leonardo category URLs in metadata

### DIFF
--- a/content/categories/official-hardware/classic/leonardo/README.md
+++ b/content/categories/official-hardware/classic/leonardo/README.md
@@ -8,4 +8,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/c/official-hardware/classic/leonardo/<!-- TODO -->
+https://forum.arduino.cc/c/official-hardware/classic/leonardo/202

--- a/content/categories/official-hardware/classic/leonardo/_pins.md
+++ b/content/categories/official-hardware/classic/leonardo/_pins.md
@@ -1,2 +1,2 @@
-- https://forum.arduino.cc/t/about-the-leonardo-category/<!-- TODO -->
-- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/<!-- TODO -->
+- https://forum.arduino.cc/t/about-the-leonardo-category/1335459
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1335460

--- a/content/categories/official-hardware/classic/leonardo/_topics/about-the-leonardo-category/README.md
+++ b/content/categories/official-hardware/classic/leonardo/_topics/about-the-leonardo-category/README.md
@@ -2,4 +2,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/t/about-the-leonardo-category/<!-- TODO -->
+https://forum.arduino.cc/t/about-the-leonardo-category/1335459


### PR DESCRIPTION
These were accidentally left in place at the time the category was added.