### PR TITLE
Add "Micro" product category

### DIFF
--- a/content/categories/official-hardware/classic/micro/README.md
+++ b/content/categories/official-hardware/classic/micro/README.md
@@ -1,0 +1,11 @@
+# Micro
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/classic/micro/203

--- a/content/categories/official-hardware/classic/micro/_pins.md
+++ b/content/categories/official-hardware/classic/micro/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-micro-category/1335464
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1335465

--- a/content/categories/official-hardware/classic/micro/_topics/about-the-micro-category/1.md
+++ b/content/categories/official-hardware/classic/micro/_topics/about-the-micro-category/1.md
@@ -1,0 +1,3 @@
+Discussion about the Micro board
+
+The [**Arduino Micro**](https://docs.arduino.cc/hardware/micro) is powered by the **ATmega32U4** microcontroller. This microcontroller has built-in USB communication, allowing the **Micro** to appear to a connected computer as USB devices such as a keyboard, mouse, or gamepad.

--- a/content/categories/official-hardware/classic/micro/_topics/about-the-micro-category/README.md
+++ b/content/categories/official-hardware/classic/micro/_topics/about-the-micro-category/README.md
@@ -1,0 +1,5 @@
+# About the Micro category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-micro-category/1335464

--- a/content/categories/official-hardware/classic/micro/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/classic/micro/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -28,6 +28,7 @@
 - Official Hardware
   - Classic
     - Leonardo
+    - Micro
     - UNO R4 Minima
     - UNO R4 WiFi
     - UNO WiFi Rev2


### PR DESCRIPTION
A dedicated forum category should be provided for each of the official hardware products. Previously there was no such category for the Micro board.