### PR TITLE
Add "UNO R3" product category

### DIFF
--- a/content/categories/official-hardware/classic/uno-r3/README.md
+++ b/content/categories/official-hardware/classic/uno-r3/README.md
@@ -1,0 +1,11 @@
+# UNO R3
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/classic/uno-r3/204

--- a/content/categories/official-hardware/classic/uno-r3/_pins.md
+++ b/content/categories/official-hardware/classic/uno-r3/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-uno-r3-category/1335467
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1335468

--- a/content/categories/official-hardware/classic/uno-r3/_topics/about-the-uno-r3-category/1.md
+++ b/content/categories/official-hardware/classic/uno-r3/_topics/about-the-uno-r3-category/1.md
@@ -1,0 +1,3 @@
+Discussion about the UNO R3 board
+
+The classic [**Arduino UNO R3**](https://docs.arduino.cc/hardware/uno-rev3/) is an excellent choice for getting started with Arduino.

--- a/content/categories/official-hardware/classic/uno-r3/_topics/about-the-uno-r3-category/README.md
+++ b/content/categories/official-hardware/classic/uno-r3/_topics/about-the-uno-r3-category/README.md
@@ -1,0 +1,5 @@
+# About the UNO R3 category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-uno-r3-category/1335467

--- a/content/categories/official-hardware/classic/uno-r3/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/classic/uno-r3/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -29,6 +29,7 @@
   - Classic
     - Leonardo
     - Micro
+    - UNO R3
     - UNO R4 Minima
     - UNO R4 WiFi
     - UNO WiFi Rev2


### PR DESCRIPTION
A dedicated forum category should be provided for each of the official hardware products. Previously there was no such category for the UNO R3 board.