### PR TITLE
Add "Pro Mini" product category

### DIFF
--- a/content/categories/official-hardware/classic/pro-mini/README.md
+++ b/content/categories/official-hardware/classic/pro-mini/README.md
@@ -1,0 +1,11 @@
+# Pro Mini
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/classic/pro-mini/205

--- a/content/categories/official-hardware/classic/pro-mini/_pins.md
+++ b/content/categories/official-hardware/classic/pro-mini/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-pro-mini-category/1335469
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1335470

--- a/content/categories/official-hardware/classic/pro-mini/_topics/about-the-pro-mini-category/1.md
+++ b/content/categories/official-hardware/classic/pro-mini/_topics/about-the-pro-mini-category/1.md
@@ -1,0 +1,3 @@
+Discussion about the Pro Mini board
+
+The [**Arduino Pro Mini**](https://docs.arduino.cc/retired/boards/arduino-pro-mini/) is a compact minimal board well suited for integration into finished projects.

--- a/content/categories/official-hardware/classic/pro-mini/_topics/about-the-pro-mini-category/README.md
+++ b/content/categories/official-hardware/classic/pro-mini/_topics/about-the-pro-mini-category/README.md
@@ -1,0 +1,5 @@
+# About the Pro Mini category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-pro-mini-category/1335469

--- a/content/categories/official-hardware/classic/pro-mini/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/classic/pro-mini/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -29,6 +29,7 @@
   - Classic
     - Leonardo
     - Micro
+    - Pro Mini
     - UNO R3
     - UNO R4 Minima
     - UNO R4 WiFi


### PR DESCRIPTION
A dedicated forum category should be provided for each of the official hardware products. Previously there was no such category for the Pro Mini board.