### PR TITLE
Add "Mega 2560" product category

### DIFF
--- a/content/categories/official-hardware/mega/mega-2560/README.md
+++ b/content/categories/official-hardware/mega/mega-2560/README.md
@@ -1,0 +1,11 @@
+# Mega 2560
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/mega/mega-2560/206

--- a/content/categories/official-hardware/mega/mega-2560/_pins.md
+++ b/content/categories/official-hardware/mega/mega-2560/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-mega-2560-category/1335474
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1335475

--- a/content/categories/official-hardware/mega/mega-2560/_topics/about-the-mega-2560-category/1.md
+++ b/content/categories/official-hardware/mega/mega-2560/_topics/about-the-mega-2560-category/1.md
@@ -1,0 +1,3 @@
+Discussion about the Mega 2560 board
+
+The [**Arduino Mega 2560**](https://docs.arduino.cc/hardware/mega-2560/) is an excellent choice for projects that require more pins or memory than the **UNO R3** can provide.

--- a/content/categories/official-hardware/mega/mega-2560/_topics/about-the-mega-2560-category/README.md
+++ b/content/categories/official-hardware/mega/mega-2560/_topics/about-the-mega-2560-category/README.md
@@ -1,0 +1,5 @@
+# About the Mega 2560 category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-mega2560-category/1335474

--- a/content/categories/official-hardware/mega/mega-2560/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/mega/mega-2560/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -48,6 +48,7 @@
     - Due
     - GIGA R1 WiFi
     - GIGA Display Shield
+    - Mega 2560
   - MKR Family
     - MKR 1000 WiFi
     - MKR FOX 1200


### PR DESCRIPTION
A dedicated forum category should be provided for each of the official hardware products. Previously there was no such category for the Mega 2560 board.