### PR TITLE
Add "Nano Motor Carrier" product category

### DIFF
--- a/content/categories/official-hardware/nano-family/nano-motor-carrier/README.md
+++ b/content/categories/official-hardware/nano-family/nano-motor-carrier/README.md
@@ -1,0 +1,11 @@
+# Nano Motor Carrier
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/nano-family/nano-motor-carrier/<!-- TODO -->

--- a/content/categories/official-hardware/nano-family/nano-motor-carrier/_pins.md
+++ b/content/categories/official-hardware/nano-family/nano-motor-carrier/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-nano-motor-carrier-category/<!-- TODO -->
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/<!-- TODO -->

--- a/content/categories/official-hardware/nano-family/nano-motor-carrier/_topics/about-the-nano-motor-carrier-category/1.md
+++ b/content/categories/official-hardware/nano-family/nano-motor-carrier/_topics/about-the-nano-motor-carrier-category/1.md
@@ -1,0 +1,3 @@
+Discussion about the Nano Motor Carrier
+
+The [**Arduino Nano Motor Carrier**](https://docs.arduino.cc/hardware/nano-motor-carrier/) provides a quick and easy way to connect motors to the [**Arduino Nano 33 IoT**](https://docs.arduino.cc/hardware/nano-33-iot/) board.

--- a/content/categories/official-hardware/nano-family/nano-motor-carrier/_topics/about-the-nano-motor-carrier-category/README.md
+++ b/content/categories/official-hardware/nano-family/nano-motor-carrier/_topics/about-the-nano-motor-carrier-category/README.md
@@ -1,0 +1,5 @@
+# About the Nano Motor Carrier category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-nano-motor-carrier-category/<!-- TODO -->

--- a/content/categories/official-hardware/nano-family/nano-motor-carrier/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/nano-family/nano-motor-carrier/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -70,6 +70,7 @@
     - Nano Every
     - Nano Matter
     - Nano RP2040 Connect
+    - Nano Motor Carrier
   - Nicla family
     - Nicla Sense ME
     - Nicla Vision


### PR DESCRIPTION
A dedicated forum category should be provided for each of the official hardware products. Previously there was no such category for the Nano Motor Carrier.