### PR TITLE
Lock "Education" product class container category

### DIFF
--- a/content/categories/official-hardware/education/README.md
+++ b/content/categories/official-hardware/education/README.md
@@ -4,7 +4,7 @@
 
 | Group    | See | Reply | Create |
 | -------- | --- | ----- | ------ |
-| everyone | ✓   | ✓     | ✓      |
+| everyone | ✓   |       |        |
 
 ## Published At
 


### PR DESCRIPTION
The subcategories of the "Official Hardware" category are organized under a subcategory for each of the product classes. The product class categories are containers for subcategories for each specific product.

Previously, the "Education" class categories was configured in a way that allowed the creation of topics directly under the categories (in addition to allowing the use of its product-specific subcategories). This was done with the idea that it would be used for the categorization of topics about Arduino Education products for which no category exists.

After surveying the previous usage of the category, it was found that there was very little legitimate use and the target of a significant amount of miscategorization. So it was decided that allowing the use of the category for topics is harmful. If it is found that there are a significant number of topics on an Arduino Education product for which no category exists, such a category should just be created. Otherwise, there are plenty of other existing open categories that will be suitable for the topics.