### PR TITLE
Lock "Retired" product class container category

### DIFF
--- a/content/categories/official-hardware/retired/README.md
+++ b/content/categories/official-hardware/retired/README.md
@@ -4,7 +4,7 @@
 
 | Group    | See | Reply | Create |
 | -------- | --- | ----- | ------ |
-| everyone | ✓   | ✓     | ✓      |
+| everyone | ✓   |       |        |
 
 ## Published At
 


### PR DESCRIPTION
The subcategories of the "Official Hardware" category are organized under a subcategory for each of the product classes. The product class categories are containers for subcategories for each specific product. Since they are not otherwise categorized, the categories for outdated products no longer manufactured by Arduino are placed under a "Retired" product class category.

Previously, the "Retired" class categories was configured in a way that allowed the creation of topics directly under the categories (in addition to allowing the use of its product-specific subcategories). This was done with the idea that it would be used for the categorization of topics about retired products for which no category exists.

After further consideration, it was decided that allowing the use of the category for topics would be is harmful as it is not a meaningful categorization and its use is likely to result in less visibility for the topic.

The category was created only recently and so did not contain any topics. For this reason, locking the category will not block the use of any existing threads.