### PR TITLE
Close deprecated categories

### DIFF
--- a/content/categories/forum-2005-2010-read-only/recycle-bin/development/README.md
+++ b/content/categories/forum-2005-2010-read-only/recycle-bin/development/README.md
@@ -4,7 +4,7 @@
 
 | Group    | See | Reply | Create |
 | -------- | --- | ----- | ------ |
-| everyone | ✓   | ✓     | ✓      |
+| everyone | ✓   |       |        |
 
 ## Published At
 

--- a/content/categories/forum-2005-2010-read-only/recycle-bin/events-and-tour/README.md
+++ b/content/categories/forum-2005-2010-read-only/recycle-bin/events-and-tour/README.md
@@ -4,7 +4,7 @@
 
 | Group | See | Reply | Create |
 | ----- | --- | ----- | ------ |
-| staff | ✓   | ✓     | ✓      |
+| staff | ✓   |       |        |
 
 ## Published At
 

--- a/content/categories/forum-2005-2010-read-only/recycle-bin/makers/README.md
+++ b/content/categories/forum-2005-2010-read-only/recycle-bin/makers/README.md
@@ -4,7 +4,7 @@
 
 | Group | See | Reply | Create |
 | ----- | --- | ----- | ------ |
-| staff | ✓   | ✓     | ✓      |
+| staff | ✓   |       |        |
 
 ## Published At
 

--- a/content/categories/other-hardware/e-textiles-and-craft/README.md
+++ b/content/categories/other-hardware/e-textiles-and-craft/README.md
@@ -4,7 +4,7 @@
 
 | Group    | See | Reply | Create |
 | -------- | --- | ----- | ------ |
-| everyone | ✓   | ✓     | ✓      |
+| everyone | ✓   | ✓     |        |
 
 ## Published At
 

--- a/content/categories/other-hardware/e-textiles-and-craft/_topics/about-the-e-textiles-and-craft-category/1.md
+++ b/content/categories/other-hardware/e-textiles-and-craft/_topics/about-the-e-textiles-and-craft-category/1.md
@@ -1,1 +1,3 @@
 Smart textiles, flexible conductive materials, electroluminescent materials
+
+This category has been closed. For new topics, please select another category that is relevant to the subject of your topic.

--- a/content/categories/other-hardware/home-automation/README.md
+++ b/content/categories/other-hardware/home-automation/README.md
@@ -4,7 +4,7 @@
 
 | Group    | See | Reply | Create |
 | -------- | --- | ----- | ------ |
-| everyone | ✓   | ✓     | ✓      |
+| everyone | ✓   | ✓     |        |
 
 ## Published At
 

--- a/content/categories/other-hardware/home-automation/_topics/about-the-home-automation-category/1.md
+++ b/content/categories/other-hardware/home-automation/_topics/about-the-home-automation-category/1.md
@@ -1,1 +1,3 @@
 Domotics, remote sensing and controlling, internet of things
+
+This category has been closed. For new topics, please select another category that is relevant to the subject of your topic.

--- a/content/categories/other-hardware/interactive-art/README.md
+++ b/content/categories/other-hardware/interactive-art/README.md
@@ -4,7 +4,7 @@
 
 | Group    | See | Reply | Create |
 | -------- | --- | ----- | ------ |
-| everyone | ✓   | ✓     | ✓      |
+| everyone | ✓   | ✓     |        |
 
 ## Published At
 

--- a/content/categories/other-hardware/interactive-art/_topics/about-the-interactive-art-category/1.md
+++ b/content/categories/other-hardware/interactive-art/_topics/about-the-interactive-art-category/1.md
@@ -1,1 +1,3 @@
 Art installations, wearable objects, music instruments, projects from the arts field
+
+This category has been closed. For new topics, please select another category that is relevant to the subject of your topic.

--- a/content/categories/other-hardware/product-design/README.md
+++ b/content/categories/other-hardware/product-design/README.md
@@ -4,7 +4,7 @@
 
 | Group    | See | Reply | Create |
 | -------- | --- | ----- | ------ |
-| everyone | ✓   | ✓     | ✓      |
+| everyone | ✓   | ✓     |        |
 
 ## Published At
 

--- a/content/categories/other-hardware/product-design/_topics/about-the-product-design-category/1.md
+++ b/content/categories/other-hardware/product-design/_topics/about-the-product-design-category/1.md
@@ -1,1 +1,3 @@
 Creating interactive prototypes of future devices
+
+This category has been closed. For new topics, please select another category that is relevant to the subject of your topic.

--- a/content/categories/other-hardware/robotics/README.md
+++ b/content/categories/other-hardware/robotics/README.md
@@ -4,7 +4,7 @@
 
 | Group    | See | Reply | Create |
 | -------- | --- | ----- | ------ |
-| everyone | ✓   | ✓     | ✓      |
+| everyone | ✓   | ✓     |        |
 
 ## Published At
 

--- a/content/categories/other-hardware/robotics/_topics/about-the-robotics-category/1.md
+++ b/content/categories/other-hardware/robotics/_topics/about-the-robotics-category/1.md
@@ -1,1 +1,3 @@
 Platforms, motors, algorithms and sensors to conform robotics projects
+
+This category has been closed. For new topics, please select another category that is relevant to the subject of your topic.

--- a/content/categories/other-hardware/science-and-measurement/README.md
+++ b/content/categories/other-hardware/science-and-measurement/README.md
@@ -4,7 +4,7 @@
 
 | Group    | See | Reply | Create |
 | -------- | --- | ----- | ------ |
-| everyone | ✓   | ✓     | ✓      |
+| everyone | ✓   | ✓     |        |
 
 ## Published At
 

--- a/content/categories/other-hardware/science-and-measurement/_topics/about-the-science-and-measurement-category/1.md
+++ b/content/categories/other-hardware/science-and-measurement/_topics/about-the-science-and-measurement-category/1.md
@@ -1,1 +1,3 @@
 Microcontrollers in scientific projects, logging and representing data
+
+This category has been closed. For new topics, please select another category that is relevant to the subject of your topic.

--- a/content/categories/projects/libraries/README.md
+++ b/content/categories/projects/libraries/README.md
@@ -4,7 +4,7 @@
 
 | Group    | See | Reply | Create |
 | -------- | --- | ----- | ------ |
-| everyone | ✓   | ✓     | ✓      |
+| everyone | ✓   | ✓     |        |
 
 ## Published At
 

--- a/content/categories/projects/libraries/_topics/about-the-libraries-category/1.md
+++ b/content/categories/projects/libraries/_topics/about-the-libraries-category/1.md
@@ -1,1 +1,3 @@
 Discussion about Arduino libraries
+
+This category has been closed. For new topics, please select another category that is relevant to the subject of your topic.


### PR DESCRIPTION
Several categories have been deemed superfluous, and will be deleted.

Some tasks need to be completed before that can be done:

- Move all topics to the remaining alternative categories
- Set up a redirect from the category URL to an equivalent page

As it will be some time before these tasks are completed, the categories are being configured to prevent the creation of new topics (which would only have to be moved by a forum maintainer). In the categories that still contain topics, the permission to reply to existing topics is preserved in order to avoid interference with ongoing discussions.