### PR TITLE
Use consistent case in category names

### DIFF
--- a/content/categories/development-tools/arduino-cli/README.md
+++ b/content/categories/development-tools/arduino-cli/README.md
@@ -1,4 +1,4 @@
-# Arduino command line tools
+# Arduino Command Line Tools
 
 ## Permissions
 

--- a/content/categories/development-tools/arduino-cli/_topics/about-the-arduino-command-line-tools-category/README.md
+++ b/content/categories/development-tools/arduino-cli/_topics/about-the-arduino-command-line-tools-category/README.md
@@ -1,4 +1,4 @@
-# About the Arduino command line tools category
+# About the Arduino Command Line Tools category
 
 ## Published At
 

--- a/content/categories/official-hardware/nicla-family/README.md
+++ b/content/categories/official-hardware/nicla-family/README.md
@@ -1,4 +1,4 @@
-# Nicla family
+# Nicla Family
 
 ## Permissions
 

--- a/content/categories/official-hardware/nicla-family/_topics/about-the-nicla-family-category/README.md
+++ b/content/categories/official-hardware/nicla-family/_topics/about-the-nicla-family-category/README.md
@@ -1,4 +1,4 @@
-# About the Nicla family category
+# About the Nicla Family category
 
 ## Published At
 

--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -10,7 +10,7 @@
   - Cloud
   - Cloud IoT
   - Cloud Chrome App
-  - Arduino command line tools
+  - Arduino Command Line Tools
   - PLC IDE
   - Windows Remote Arduino
   - Windows Virtual Shields for Arduino
@@ -69,7 +69,7 @@
     - Nano Matter
     - Nano RP2040 Connect
     - Nano Motor Carrier
-  - Nicla family
+  - Nicla Family
     - Nicla Sense ME
     - Nicla Vision
     - Nicla Voice


### PR DESCRIPTION
The established convention is to use title case for category names. Previously these categories did not comply with that convention.