### PR TITLE
Adjust placeholder location to gracefully handle non-replacement

### DIFF
--- a/content/categories/templates/_topics/moved-to-nederlands-category/1.md
+++ b/content/categories/templates/_topics/moved-to-nederlands-category/1.md
@@ -1,4 +1,4 @@
-<!-- TODO: @username -->, je bericht is verhuisd naar een geschiktere forum categorie.
+Je bericht is verhuisd naar een geschiktere forum categorie <!-- TODO: @username -->.
 
 Neem in de toekomst a.u.b. wat tijd nemen om de meest geschikte ([forum categorie](https://forum.arduino.cc/categories)) te kiezen voor je onderwerp. Er is een "**About the \_\_\_\_\_ category**" onderwerp aan de top van iedere categorie die het doel van die categorie aangeeft.
 

--- a/content/categories/templates/_topics/moved-to-nederlands-category/README.md
+++ b/content/categories/templates/_topics/moved-to-nederlands-category/README.md
@@ -1,5 +1,7 @@
 # Moved to Nederlands category
 
+Translation contributed by forum user **sterretje**.
+
 ## Published At
 
 https://forum.arduino.cc/t/moved-to-nederlands-category/1343756 (private)


### PR DESCRIPTION
The "Moved to Nederlands category" post template contains a placeholder which the template user should replace with a username mention at the time of posting.

The template user might forget to make this replacement. The placeholder is in the form of an HTML comment tag, so will simply not be rendered in the published post if this occurs. With the previous placement of the placeholder at the start of a sentence, the published post would have an obviously incorrect form. By moving the placeholder to the end of the sentence, this eventually is mitigated down to only a single excess space in the published post.

The new sentence form is grammatically valid and approximately equivalent to the previous form.

---

Translation contributed by @sterretjeToo (thanks!)