### PR TITLE
Move "Staff" category to lower position in category list

### DIFF
--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -1,6 +1,3 @@
-- Staff
-  - Moderation
-  - TEST
 - Development Tools
   - Uncategorized
   - IDE 2.x
@@ -141,6 +138,9 @@
   - Português
   - Россия - Russia
   - Scandinavia
+- Staff
+  - Moderation
+  - TEST
 - Forum 2005-2010 (read only)
   - General
     - Uno Punto Zero


### PR DESCRIPTION
The "Staff" category is used for internal discussions by Arduino Forum staff (moderators and administrators). Although the category does serve an important purpose, it is infrequently used.

Previously the category was placed at the very top of the category list. This prominent placement was not proportionate to its usage. By moving it to a position below the categories that are more frequently used by staff members, the user experience will be improved for the staff members.