### PR TITLE
Remove write permissions for "Official Hardware" category

### DIFF
--- a/content/categories/official-hardware/README.md
+++ b/content/categories/official-hardware/README.md
@@ -4,7 +4,7 @@
 
 | Group    | See | Reply | Create |
 | -------- | --- | ----- | ------ |
-| everyone | ✓   | ✓     | ✓      |
+| everyone | ✓   |       |        |
 
 ## Published At
 


### PR DESCRIPTION
Previously, creation of topics was permitted in the root of the "Official Hardware" category, with the category serving as a "catch-all" for topics about official hardware for which no dedicated category existed.

The need for such a "catch-all" is lesser now that categories have been created for significant official hardware products. The value of such a general category for topics was questionable. The general practice of allowing topics in parent categories is also questionable. So the decision was made to use this only as a container for subcategories. All topics have been moved out of the category.

The category's permissions are hereby updated to prevent the creation of new topics.