### PR TITLE
Restore visibility of deprecated categories

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -21,12 +21,6 @@
       "pattern": "^https://chromewebstore\\.google\\.com/detail/arduino-create-for-educat/elmgohdonjdampbcgefphnlchgocpaij$"
     },
     {
-      "pattern": "^https://forum\\.arduino\\.cc/c/forum-2005-2010-read-only/recycle-bin/events-and-tour/"
-    },
-    {
-      "pattern": "^https://forum\\.arduino\\.cc/c/forum-2005-2010-read-only/recycle-bin/makers/"
-    },
-    {
       "pattern": "^https://forum\\.arduino\\.cc/c/official-hardware/mkr-boards/mkr1000-old/"
     },
     {
@@ -43,12 +37,6 @@
     },
     {
       "pattern": "^https://forum\\.arduino\\.cc/t/about-the-cloud-category/847576$"
-    },
-    {
-      "pattern": "^https://forum\\.arduino\\.cc/t/about-the-events-and-tour-category/847508$"
-    },
-    {
-      "pattern": "^https://forum\\.arduino\\.cc/t/about-the-makers-category/847507$"
     },
     {
       "pattern": "^https://forum\\.arduino\\.cc/t/about-the-mkr1000-old-category/847575$"
@@ -76,9 +64,6 @@
     },
     {
       "pattern": "^https://forum\\.arduino\\.cc/t/flag-for-post-making-responsible-use-of-ai-generated-content/1289013$"
-    },
-    {
-      "pattern": "^https://forum\\.arduino\\.cc/t/hi-welcome-to-maker-faire-rome-the-european-edition/158299$"
     },
     {
       "pattern": "^https://forum\\.arduino\\.cc/t/how-to-get-the-best-out-of-this-forum/1114083$"

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -15,16 +15,10 @@
       "pattern": "^/"
     },
     {
-      "pattern": "^https://cloud\\.arduino\\.cc/cloud$"
-    },
-    {
       "pattern": "^https://chromewebstore\\.google\\.com/detail/arduino-create-for-educat/elmgohdonjdampbcgefphnlchgocpaij$"
     },
     {
       "pattern": "^https://forum\\.arduino\\.cc/c/official-hardware/mkr-boards/mkr1000-old/"
-    },
-    {
-      "pattern": "^https://forum\\.arduino\\.cc/c/official-hardware/uno-r4/"
     },
     {
       "pattern": "^https://forum\\.arduino\\.cc/c/staff/"
@@ -34,9 +28,6 @@
     },
     {
       "pattern": "^https://forum\\.arduino\\.cc/review$"
-    },
-    {
-      "pattern": "^https://forum\\.arduino\\.cc/t/about-the-cloud-category/847576$"
     },
     {
       "pattern": "^https://forum\\.arduino\\.cc/t/about-the-mkr1000-old-category/847575$"
@@ -54,9 +45,6 @@
       "pattern": "^https://forum\\.arduino\\.cc/t/about-the-test-category/847511$"
     },
     {
-      "pattern": "^https://forum\\.arduino\\.cc/t/about-the-uno-r4-category/1114082$"
-    },
-    {
       "pattern": "^https://forum\\.arduino\\.cc/t/content-deletion-escalation/1329581$"
     },
     {
@@ -64,9 +52,6 @@
     },
     {
       "pattern": "^https://forum\\.arduino\\.cc/t/flag-for-post-making-responsible-use-of-ai-generated-content/1289013$"
-    },
-    {
-      "pattern": "^https://forum\\.arduino\\.cc/t/how-to-get-the-best-out-of-this-forum/1114083$"
     },
     {
       "pattern": "^https://forum\\.arduino\\.cc/t/moderation-guidelines/54905$"

--- a/content/categories/forum-2005-2010-read-only/recycle-bin/events-and-tour/README.md
+++ b/content/categories/forum-2005-2010-read-only/recycle-bin/events-and-tour/README.md
@@ -2,10 +2,10 @@
 
 ## Permissions
 
-| Group | See | Reply | Create |
-| ----- | --- | ----- | ------ |
-| staff | ✓   |       |        |
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
 
 ## Published At
 
-https://forum.arduino.cc/c/forum-2005-2010-read-only/recycle-bin/events-and-tour/68 (private)
+https://forum.arduino.cc/c/forum-2005-2010-read-only/recycle-bin/events-and-tour/68

--- a/content/categories/forum-2005-2010-read-only/recycle-bin/events-and-tour/_pins.md
+++ b/content/categories/forum-2005-2010-read-only/recycle-bin/events-and-tour/_pins.md
@@ -1,1 +1,1 @@
-- https://forum.arduino.cc/t/about-the-events-and-tour-category/847508 (private)
+- https://forum.arduino.cc/t/about-the-events-and-tour-category/847508

--- a/content/categories/forum-2005-2010-read-only/recycle-bin/events-and-tour/_topics/about-the-events-and-tour-category/README.md
+++ b/content/categories/forum-2005-2010-read-only/recycle-bin/events-and-tour/_topics/about-the-events-and-tour-category/README.md
@@ -2,4 +2,4 @@
 
 ## Published At
 
-https://forum.arduino.cc/t/about-the-events-and-tour-category/847508 (private)
+https://forum.arduino.cc/t/about-the-events-and-tour-category/847508

--- a/content/categories/forum-2005-2010-read-only/recycle-bin/makers/README.md
+++ b/content/categories/forum-2005-2010-read-only/recycle-bin/makers/README.md
@@ -2,10 +2,10 @@
 
 ## Permissions
 
-| Group | See | Reply | Create |
-| ----- | --- | ----- | ------ |
-| staff | ✓   |       |        |
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
 
 ## Published At
 
-https://forum.arduino.cc/c/forum-2005-2010-read-only/recycle-bin/makers/67 (private)
+https://forum.arduino.cc/c/forum-2005-2010-read-only/recycle-bin/makers/67

--- a/content/categories/forum-2005-2010-read-only/recycle-bin/makers/_pins.md
+++ b/content/categories/forum-2005-2010-read-only/recycle-bin/makers/_pins.md
@@ -1,2 +1,2 @@
-- https://forum.arduino.cc/t/about-the-makers-category/847507 (private)
-- https://forum.arduino.cc/t/hi-welcome-to-maker-faire-rome-the-european-edition/158299 (private)
+- https://forum.arduino.cc/t/about-the-makers-category/847507
+- https://forum.arduino.cc/t/hi-welcome-to-maker-faire-rome-the-european-edition/158299

--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -35,6 +35,7 @@
     - Science Journal & Science Kit
     - Starter Kit Classroom Pack
   - Kits
+    - Plug and Make Kit
     - Starter Kit
   - Mega
     - Due


### PR DESCRIPTION
Previously, in order to reduce the clutter of the forum's category structure, the permissions of these deprecated categories were configured to cause them to not be publicly visible.

Since then, the alternative approach has been adopted of moving deprecated categories under a "Recycle Bin" category, which is public but not shown in the primary topic listings. The previous approach is potentially harmful in that it would break any links to the category itself (though not to the posts that had been moved out of the category, since post URLs are not category-dependent).

Making the categories visible once more avoids the breakage of any links to the category.