### PR TITLE
Add Dutch language user guide link to "Moved to Nederlands category" template

### DIFF
--- a/content/categories/templates/_topics/moved-to-nederlands-category/1.md
+++ b/content/categories/templates/_topics/moved-to-nederlands-category/1.md
@@ -2,6 +2,6 @@ Je bericht is verhuisd naar een geschiktere forum categorie <!-- TODO: @username
 
 Neem in de toekomst a.u.b. wat tijd nemen om de meest geschikte ([forum categorie](https://forum.arduino.cc/categories)) te kiezen voor je onderwerp. Er is een "**About the \_\_\_\_\_ category**" onderwerp aan de top van iedere categorie die het doel van die categorie aangeeft.
 
-Dit is een belangrijk onderdeel van het verantwoordelijk gebruik van het forum zoals is uitgelegd in [de gids "**How to get the best out of this forum**"](https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966). Deze gids bevat ook een weelde aan andere informatie, lees het a.u.b.
+Dit is een belangrijk onderdeel van het verantwoordelijk gebruik van het forum zoals is uitgelegd in de [Nederlandse gids "**Hoe haal je het meeste uit het forum**"](https://forum.arduino.cc/t/hoe-haal-je-het-meeste-uit-het-forum/1344278) en in de uitgebreidere [Engelse gids "**How to get the best out of this forum**"](https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966). Deze gidsen bevatten ook een weelde aan andere informatie, lees het a.u.b.
 
 Bij voorbaat dank voor je medewerking.


### PR DESCRIPTION
The "Moved to Nederlands category" post template contains a link to the forum user guide.

Previously, due to the Dutch language guide being outdated, the template only linked to the English language guide. A modern Dutch language guide has now been published, and so a link to that guide is now added to the template.

---

Translation contributed by @sterretjeToo (thanks!).