### PR TITLE
Correct microcontroller name in "About the Nano ESP32 category" post

### DIFF
--- a/content/categories/official-hardware/nano-family/nano-esp32/_topics/about-the-nano-esp32-category/1.md
+++ b/content/categories/official-hardware/nano-family/nano-esp32/_topics/about-the-nano-esp32-category/1.md
@@ -1,3 +1,3 @@
 Discussion about the Nano ESP32 board.
 
-The Nano ESP32 is based on the Espressif ESP32 microcontroller.
+The Nano ESP32 is based on the Espressif ESP32-S3 microcontroller.


### PR DESCRIPTION
The Nano ESP32 board uses the ESP32-S3 microcontroller. The post previously stated that it uses "the ESP32" microcontroller. Although the ESP32-S3 is one model in the ESP32 family of microcontrollers, it is not accurate to say the board uses "the ESP32" microcontroller, as that implies it uses the classic ESP32 (which is another specific model, which has the same name as the family).