### PR TITLE
Revert "Disable internal anchor checks by link checker tool"

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -9,9 +9,6 @@
   ],
   "ignorePatterns": [
     {
-      "pattern": "^#"
-    },
-    {
       "pattern": "^/"
     },
     {


### PR DESCRIPTION
This reverts commit cfd1546e61279a47a195c0b1a5c41e8c231882f4.

This configuration entry was previously required in order to work around a bug in the [**markdown-link-check**](https://github.com/tcort/markdown-link-check) tool (https://github.com/tcort/markdown-link-check/issues/202) that resulted in false positives for links to anchors created by HTML anchor tags.

The bug in the "markdown-link-check" tool has since been fixed (https://github.com/tcort/markdown-link-check/pull/331), and this project updated to use the version of the tool with that fix (https://github.com/arduino/forum-assets/pull/587). So this configuration entry is no longer required.

The now superfluous configuration entry is hereby removed in order to ensure more comprehensive link check coverage, and avoid unnecessary clutter in the "markdown-link-check" configuration file.