### PR TITLE
Add categories for Modulino Nodes products

### DIFF
--- a/content/categories/official-hardware/accessories/README.md
+++ b/content/categories/official-hardware/accessories/README.md
@@ -1,0 +1,11 @@
+# Accessories
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   |       |        |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/accessories/213

--- a/content/categories/official-hardware/accessories/_pins.md
+++ b/content/categories/official-hardware/accessories/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-accessories-category/1383659
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1383660

--- a/content/categories/official-hardware/accessories/_topics/about-the-accessories-category/1.md
+++ b/content/categories/official-hardware/accessories/_topics/about-the-accessories-category/1.md
@@ -1,0 +1,1 @@
+Official Arduino hardware accessories

--- a/content/categories/official-hardware/accessories/_topics/about-the-accessories-category/README.md
+++ b/content/categories/official-hardware/accessories/_topics/about-the-accessories-category/README.md
@@ -1,0 +1,5 @@
+# About the Accessories category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-accessories-category/1383659

--- a/content/categories/official-hardware/accessories/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/accessories/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/official-hardware/accessories/modulino-buttons/README.md
+++ b/content/categories/official-hardware/accessories/modulino-buttons/README.md
@@ -1,0 +1,11 @@
+# Modulino Buttons
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/accessories/modulino-buttons/214

--- a/content/categories/official-hardware/accessories/modulino-buttons/_pins.md
+++ b/content/categories/official-hardware/accessories/modulino-buttons/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-modulino-buttons-category/1383662
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1383663

--- a/content/categories/official-hardware/accessories/modulino-buttons/_topics/about-the-modulino-buttons-category/1.md
+++ b/content/categories/official-hardware/accessories/modulino-buttons/_topics/about-the-modulino-buttons-category/1.md
@@ -1,0 +1,7 @@
+**Modulino Buttons** provides 3 buttons with LEDs that indicate button presses
+
+Use this category for topics where the primary subject matter is the **Arduino Modulino Buttons** product.
+
+The standardized QWIIC connectors on the **Arduino Modulino Buttons** allows it to be easily connected with any of the range of devices that use this connector.
+
+https://docs.arduino.cc/hardware/modulino-buttons/

--- a/content/categories/official-hardware/accessories/modulino-buttons/_topics/about-the-modulino-buttons-category/README.md
+++ b/content/categories/official-hardware/accessories/modulino-buttons/_topics/about-the-modulino-buttons-category/README.md
@@ -1,0 +1,5 @@
+# About the Modulino Buttons category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-modulino-buttons-category/1383662

--- a/content/categories/official-hardware/accessories/modulino-buttons/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/accessories/modulino-buttons/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/official-hardware/accessories/modulino-buzzer/README.md
+++ b/content/categories/official-hardware/accessories/modulino-buzzer/README.md
@@ -1,0 +1,11 @@
+# Modulino Buzzer
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/accessories/modulino-buzzer/215

--- a/content/categories/official-hardware/accessories/modulino-buzzer/_pins.md
+++ b/content/categories/official-hardware/accessories/modulino-buzzer/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-modulino-buzzer-category/1383664
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1383666

--- a/content/categories/official-hardware/accessories/modulino-buzzer/_topics/about-the-modulino-buzzer-category/1.md
+++ b/content/categories/official-hardware/accessories/modulino-buzzer/_topics/about-the-modulino-buzzer-category/1.md
@@ -1,0 +1,7 @@
+**Modulino Buzzer** provides a buzzer for audible output
+
+Use this category for topics where the primary subject matter is the **Arduino Modulino Buzzer** product.
+
+The standardized QWIIC connectors on the **Arduino Modulino Buzzer** allows it to be easily connected with any of the range of devices that use this connector.
+
+https://docs.arduino.cc/hardware/modulino-buzzer/

--- a/content/categories/official-hardware/accessories/modulino-buzzer/_topics/about-the-modulino-buzzer-category/README.md
+++ b/content/categories/official-hardware/accessories/modulino-buzzer/_topics/about-the-modulino-buzzer-category/README.md
@@ -1,0 +1,5 @@
+# About the Modulino Buzzer category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-modulino-buzzer-category/1383664

--- a/content/categories/official-hardware/accessories/modulino-buzzer/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/accessories/modulino-buzzer/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/official-hardware/accessories/modulino-distance/README.md
+++ b/content/categories/official-hardware/accessories/modulino-distance/README.md
@@ -1,0 +1,11 @@
+# Modulino Distance
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/accessories/modulino-distance/216

--- a/content/categories/official-hardware/accessories/modulino-distance/_pins.md
+++ b/content/categories/official-hardware/accessories/modulino-distance/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-modulino-distance-category/1383668
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1383669

--- a/content/categories/official-hardware/accessories/modulino-distance/_topics/about-the-modulino-distance-category/1.md
+++ b/content/categories/official-hardware/accessories/modulino-distance/_topics/about-the-modulino-distance-category/1.md
@@ -1,0 +1,7 @@
+**Modulino Distance** provides a precise time-of-flight distance sensor
+
+Use this category for topics where the primary subject matter is the **Arduino Modulino Distance** product.
+
+The standardized QWIIC connectors on the **Arduino Modulino Distance** allows it to be easily connected with any of the range of devices that use this connector.
+
+https://docs.arduino.cc/hardware/modulino-distance/

--- a/content/categories/official-hardware/accessories/modulino-distance/_topics/about-the-modulino-distance-category/README.md
+++ b/content/categories/official-hardware/accessories/modulino-distance/_topics/about-the-modulino-distance-category/README.md
@@ -1,0 +1,5 @@
+# About the Modulino Distance category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-modulino-distance-category/1383668

--- a/content/categories/official-hardware/accessories/modulino-distance/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/accessories/modulino-distance/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/official-hardware/accessories/modulino-knob/README.md
+++ b/content/categories/official-hardware/accessories/modulino-knob/README.md
@@ -1,0 +1,11 @@
+# Modulino Knob
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/accessories/modulino-knob/217

--- a/content/categories/official-hardware/accessories/modulino-knob/_pins.md
+++ b/content/categories/official-hardware/accessories/modulino-knob/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-modulino-knob-category/1383672
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1383673

--- a/content/categories/official-hardware/accessories/modulino-knob/_topics/about-the-modulino-knob-category/1.md
+++ b/content/categories/official-hardware/accessories/modulino-knob/_topics/about-the-modulino-knob-category/1.md
@@ -1,0 +1,7 @@
+**Modulino Knob** provides a rotary encoder and integrated button
+
+Use this category for topics where the primary subject matter is the **Arduino Modulino Knob** product.
+
+The standardized QWIIC connectors on the **Arduino Modulino Knob** allows it to be easily connected with any of the range of devices that use this connector.
+
+https://docs.arduino.cc/hardware/modulino-knob/

--- a/content/categories/official-hardware/accessories/modulino-knob/_topics/about-the-modulino-knob-category/README.md
+++ b/content/categories/official-hardware/accessories/modulino-knob/_topics/about-the-modulino-knob-category/README.md
@@ -1,0 +1,5 @@
+# About the Modulino Knob category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-modulino-knob-category/1383672

--- a/content/categories/official-hardware/accessories/modulino-knob/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/accessories/modulino-knob/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/official-hardware/accessories/modulino-movement/README.md
+++ b/content/categories/official-hardware/accessories/modulino-movement/README.md
@@ -1,0 +1,11 @@
+# Modulino Movement
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/accessories/modulino-movement/218

--- a/content/categories/official-hardware/accessories/modulino-movement/_pins.md
+++ b/content/categories/official-hardware/accessories/modulino-movement/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-modulino-movement-category/1383674
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1383676

--- a/content/categories/official-hardware/accessories/modulino-movement/_topics/about-the-modulino-movement-category/1.md
+++ b/content/categories/official-hardware/accessories/modulino-movement/_topics/about-the-modulino-movement-category/1.md
@@ -1,0 +1,7 @@
+**Modulino Movement** provides a 6-axis IMU
+
+Use this category for topics where the primary subject matter is the **Arduino Modulino Movement** product.
+
+The standardized QWIIC connectors on the **Arduino Modulino Movement** allows it to be easily connected with any of the range of devices that use this connector.
+
+https://docs.arduino.cc/hardware/modulino-movement/

--- a/content/categories/official-hardware/accessories/modulino-movement/_topics/about-the-modulino-movement-category/README.md
+++ b/content/categories/official-hardware/accessories/modulino-movement/_topics/about-the-modulino-movement-category/README.md
@@ -1,0 +1,5 @@
+# About the Modulino Movement category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-modulino-movement-category/1383674

--- a/content/categories/official-hardware/accessories/modulino-movement/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/accessories/modulino-movement/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/official-hardware/accessories/modulino-pixels/README.md
+++ b/content/categories/official-hardware/accessories/modulino-pixels/README.md
@@ -1,0 +1,11 @@
+# Modulino Pixels
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/accessories/modulino-pixels/219

--- a/content/categories/official-hardware/accessories/modulino-pixels/_pins.md
+++ b/content/categories/official-hardware/accessories/modulino-pixels/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-modulino-pixels-category/1383677
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1383678

--- a/content/categories/official-hardware/accessories/modulino-pixels/_topics/about-the-modulino-pixels-category/1.md
+++ b/content/categories/official-hardware/accessories/modulino-pixels/_topics/about-the-modulino-pixels-category/1.md
@@ -1,0 +1,7 @@
+**Modulino Pixels** provides eight customizable RGB LEDs
+
+Use this category for topics where the primary subject matter is the **Arduino Modulino Pixels** product.
+
+The standardized QWIIC connectors on the **Arduino Modulino Pixels** allows it to be easily connected with any of the range of devices that use this connector.
+
+https://docs.arduino.cc/hardware/modulino-pixels/

--- a/content/categories/official-hardware/accessories/modulino-pixels/_topics/about-the-modulino-pixels-category/README.md
+++ b/content/categories/official-hardware/accessories/modulino-pixels/_topics/about-the-modulino-pixels-category/README.md
@@ -1,0 +1,5 @@
+# About the Modulino Pixels category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-modulino-pixels-category/1383677

--- a/content/categories/official-hardware/accessories/modulino-pixels/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/accessories/modulino-pixels/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/official-hardware/accessories/modulino-thermo/README.md
+++ b/content/categories/official-hardware/accessories/modulino-thermo/README.md
@@ -1,0 +1,11 @@
+# Modulino Thermo
+
+## Permissions
+
+| Group    | See | Reply | Create |
+| -------- | --- | ----- | ------ |
+| everyone | ✓   | ✓     | ✓      |
+
+## Published At
+
+https://forum.arduino.cc/c/official-hardware/accessories/modulino-thermo/220

--- a/content/categories/official-hardware/accessories/modulino-thermo/_pins.md
+++ b/content/categories/official-hardware/accessories/modulino-thermo/_pins.md
@@ -1,0 +1,2 @@
+- https://forum.arduino.cc/t/about-the-modulino-thermo-category/1383679
+- https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/1383680

--- a/content/categories/official-hardware/accessories/modulino-thermo/_topics/about-the-modulino-thermo-category/1.md
+++ b/content/categories/official-hardware/accessories/modulino-thermo/_topics/about-the-modulino-thermo-category/1.md
@@ -1,0 +1,7 @@
+**Modulino Thermo** provides a temperature and humidity sensor
+
+Use this category for topics where the primary subject matter is the **Arduino Modulino Thermo** product.
+
+The standardized QWIIC connectors on the **Arduino Modulino Thermo** allows it to be easily connected with any of the range of devices that use this connector.
+
+https://docs.arduino.cc/hardware/modulino-thermo/

--- a/content/categories/official-hardware/accessories/modulino-thermo/_topics/about-the-modulino-thermo-category/README.md
+++ b/content/categories/official-hardware/accessories/modulino-thermo/_topics/about-the-modulino-thermo-category/README.md
@@ -1,0 +1,5 @@
+# About the Modulino Thermo category
+
+## Published At
+
+https://forum.arduino.cc/t/about-the-modulino-thermo-category/1383679

--- a/content/categories/official-hardware/accessories/modulino-thermo/_topics/how-to-get-the-best-out-of-this-forum
+++ b/content/categories/official-hardware/accessories/modulino-thermo/_topics/how-to-get-the-best-out-of-this-forum
@@ -1,0 +1,1 @@
+../../../../../_topics/how-to-get-the-best-out-of-this-forum

--- a/content/categories/order.md
+++ b/content/categories/order.md
@@ -17,6 +17,14 @@
   - Showcase
   - Libraries
 - Official Hardware
+  - Accessories
+    - Modulino Buttons
+    - Modulino Buzzer
+    - Modulino Distance
+    - Modulino Knob
+    - Modulino Movement
+    - Modulino Pixels
+    - Modulino Thermo
   - Classic
     - Leonardo
     - Micro


### PR DESCRIPTION
Arduino has created a "Modulino" system of hardware products, which include accessory "node" modules.

Dedicated forum categories are hereby created to support these official products.