### PR TITLE
Correct board name in "About the Nano Matter category" post

### DIFF
--- a/content/categories/official-hardware/nano-family/nano-matter/_topics/about-the-nano-matter-category/1.md
+++ b/content/categories/official-hardware/nano-family/nano-matter/_topics/about-the-nano-matter-category/1.md
@@ -1,3 +1,3 @@
 Discussion about the Nano Matter board.
 
-The Nano ESP32 is based on the Silicon Labs MGM240S microcontroller.
+The Nano Matter is based on the Silicon Labs MGM240S microcontroller.


### PR DESCRIPTION
A copy paste error resulted in the presence of an incorrect board name in the post.