### PR TITLE
Standardize wording of "Moved to German section" post template

### DIFF
--- a/content/categories/templates/_topics/moved-to-german-section/1.md
+++ b/content/categories/templates/_topics/moved-to-german-section/1.md
@@ -1,4 +1,5 @@
-:warning:
-Im englischen Teil des Forum müssen die Beiträge und Diskussionen in englischer Sprache verfasst werden.
-Deswegen wurde diese Diskussion in den deutschen Teil des Forums verschoben.
-mfg ein Moderator.
+Ich habe Ihr Thema aus einer englischsprachigen Kategorie in die Kategorie **International > Deutsch** des Forums verschoben <!-- TODO: @username -->.
+
+Bitte posten Sie zukünftig jeweils in der Kategorie, die der von Ihnen verwendeten Sprache entspricht. Dies ist ein wesentlicher Teil des verantwortungsvollen Umgangs im Forum, wie es auch in der [Anleitung "**Wie man dieses Forum benutzt**"](https://forum.arduino.cc/t/wie-man-dieses-forum-benutzt-bitte-lesen/902274) erläutert wird. Diese Anleitung beinhaltet viele weitere nützliche Informationen. Bitte unbedingt lesen!
+
+Vielen Dank im Voraus für Ihre Mitarbeit!


### PR DESCRIPTION
In order to ensure effective communication with the subject, and to comply with the rules of the forum category, a separate localized version of the recategorization notification template is provided for each of the "international" categories.

The previous version of the template was produced some time ago. Since that time, the target wording of the template has been improved. The goal is for each localization of the template to be consistent in wording, so the each localization of the template must be updated accordingly.

This translation was contributed by Arduino Forum user ec2021.