### PR TITLE
Rescind official status of "moderation guidelines" topic

### DIFF
--- a/content/categories/staff/moderation/_pins.md
+++ b/content/categories/staff/moderation/_pins.md
@@ -1,4 +1,3 @@
 - https://forum.arduino.cc/t/about-the-moderation-category/847500 (private)
 - https://forum.arduino.cc/t/moderator-instructions/630548 (private)
 - https://forum.arduino.cc/t/about-user-account-deletion-and-user-content-deletion/627095 (private)
-- https://forum.arduino.cc/t/moderation-guidelines/54905 (private)

--- a/content/categories/staff/moderation/_topics/moderator-instructions/1.md
+++ b/content/categories/staff/moderation/_topics/moderator-instructions/1.md
@@ -1,7 +1,5 @@
 These are instructions for common moderation actions.
 
-For general moderation guidelines, see the ["**Moderator Guidelines**" topic](https://forum.arduino.cc/t/moderation-guidelines/54905).
-
 For an overview of the Discourse moderation system, see the "[**Discourse Moderation Guide**](https://meta.discourse.org/t/discourse-moderation-guide/63116)".
 
 ---

--- a/content/categories/staff/moderation/_topics/moderator-instructions/README.md
+++ b/content/categories/staff/moderation/_topics/moderator-instructions/README.md
@@ -11,7 +11,6 @@
 ## Related
 
 - [Forum topic for related discussion](https://forum.arduino.cc/t/discussion-re-moderator-documentation-content/852461) (private)
-- https://forum.arduino.cc/t/moderation-guidelines/54905 (private)
 - https://forum.arduino.cc/t/draft-proposal-for-moderator-documentation/623114 (private)
 - https://meta.discourse.org/t/discourse-moderation-guide/63116
 - https://forum.arduino.cc/t/about-user-account-deletion-and-user-content-deletion/627095 (private)


### PR DESCRIPTION
Although well written, this post is very old and thus contains outdated information that would lead the reader astray.

Furthermore, it exceeds its scope by straying into making a half-hearted attempt at defining moderation procedures. A well maintained comprehensive dedicated document has since been created for that purpose, making those parts of the post redundant as well as obsolete.

Since the author of the post is no longer active on the forum, it would be too challenging to attempt to collaborate with them to revise the post to something that is of overall benefit now. For this reason, it is best to just unpin it and remove links to it from other assets.