### PR TITLE
Moderation Procedures: Remove outdated note re: "Staff Notice"

### DIFF
--- a/content/categories/staff/moderation/_topics/moderation-procedures/1.md
+++ b/content/categories/staff/moderation/_topics/moderation-procedures/1.md
@@ -1139,12 +1139,6 @@ User notes can be associated with a post. These are the same as the [User Notes 
 
 Moderators can mark their posts with a "Staff Color", which is intended to give it emphasis as an official proclamation.
 
----
-
-**ⓘ** This is not the same as the similarly named "Staff Notice". Due to serving no useful purpose, "Staff Notices" should not be used.
-
----
-
 1. Make a post as usual, whether that be a topic or reply.
 1. Click the **⬤⬤⬤** icon at the bottom of the post to be given the "Staff Color".
 1. Click the wrench icon.


### PR DESCRIPTION
Previously, the forum had a feature named "Staff Notice". Due to the similarity of the feature name, a note about this feature was added to the instructions for using the "Add Staff Color" feature.

"Staff Notice" has since been renamed "Official Notice". Since the feature's new name is distinct, there is no need to mention it in the instructions for using "Add Staff Color".