### PR TITLE
Moderation Procedures: Utilize templates

### DIFF
--- a/content/categories/staff/moderation/_topics/moderation-procedures/1.md
+++ b/content/categories/staff/moderation/_topics/moderation-procedures/1.md
@@ -49,6 +49,7 @@ For an overview of the Discourse moderation system, see the "[**Discourse Modera
   - [Split topic](#split-topic)
   - [Suspend account](#suspend-account)
   - [Change post ownership](#change-post-ownership)
+  - [Use post template](#use-post-template)
 - [Resources](#resources)
 - [Feedback and discussion](#feedback-and-discussion)
 
@@ -655,6 +656,7 @@ Topics written in a language for which there is not a dedicated board may be lef
    This will detect the language and allow you to determine the subject matter.
    ❗ It's easy for someone unfamiliar with the language to mistake Portuguese for Spanish.
 1. Follow the ["**Move topic to correct category**" instructions](#move-topic-to-correct-category) to move the topic to the appropriate category.
+1. Reply to the topic to warn the user. Use the relevant template for the subject language, following the procedure [**here**](#use-post-template).
 
 ---
 
@@ -672,16 +674,7 @@ A cross-post is when a user posts on the same subject to the forum multiple time
 1. Follow the instructions below to [delete](#if-the-post-to-be-removed-has-no-valuable-replies) or [merge](#if-the-post-to-be-removed-has-valuable-replies) the other cross-posts.
 1. Add a "[**User Note**](#add-user-note)" to document the rule violation.
    If the user notes indicate a history of repeated cross-posting, take more severe moderation action, as described in the "[**Deal with inappropriate behavior**](#deal-with-inappropriate-behavior)" instructions.
-1. In a reply to the cross-post to be kept, add a ["Staff Post"](#make-staff-post):
-   > I've deleted/merged your other cross-post(s).
-   >
-   > Cross-posting is against the rules of the forum. The reason is that duplicate posts can waste the time of the people trying to help. Someone might spend 15 minutes (or more) writing a detailed answer on this topic, without knowing that someone else already did the same in the other topic.
-   >
-   > Repeated cross-posting will result in a suspension from the forum.
-   >
-   > In the future, please take some time to pick the forum board that best suits the topic of your question and then only post once to that forum board. This is basic forum etiquette, as explained in the [**"How to get the best out of this forum"**](https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966) guide. It contains a lot of other useful information. Please read it.
-   >
-   > Thanks in advance for your cooperation.
+1. Reply to the cross-post that was kept to warn the user. Use the "**Crosspost deleted**" or "**Crosspost merged**" template, following the procedure [**here**](#use-post-template).
 
 <a name="if-the-post-to-be-removed-has-no-valuable-replies"></a>
 
@@ -743,12 +736,7 @@ A topic hijack is when a user makes a reply that is not relevant to the topic. T
 
 1. Open the hijacked topic.
 1. Follow the ["**Split topic**" procedure](#split-topic) to move the posts specific to the hijack to a new topic.
-1. In a reply to the newly created topic, add a ["Staff Post"](#make-staff-post):
-   > Please don't hijack topics. I've had to split your post out to its own topic.
-   >
-   > This is basic forum etiquette, as explained in the [**"How to get the best out of this forum"**](https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966) guide. It contains a lot of other useful information. Please read it.
-   >
-   > Thanks in advance for your cooperation.
+1. Reply on the new topic to warn the user. Use the "**Topic split from another topic**" template, following the procedure [**here**](#use-post-template).
 
 ---
 
@@ -815,6 +803,8 @@ This chart provides an overview of the workflow:
 
 ![content-deletion-handling-overview|227x500](upload://xCkOx3T4FX7dQwQHz4s8T5AK9Ns.png)
 
+This procedure utilizes post templates. See the instructions [**here**](#use-post-template).
+
 ---
 
 <a name="redirect-content-deletion"></a>
@@ -832,6 +822,8 @@ The goal behind the request is the user does not want further discussion in thei
 <!-- Source: https://github.com/arduino/forum-assets/blob/main/content/categories/staff/moderation/_topics/moderation-procedures/_assets/redirect-content-deletion-closure.mmd -->
 
 ![redirect-content-deletion-closure|204x500, 75%](upload://8sUHXjXuN2pwiSjPXhsXrJxEgQi.png)
+
+This procedure utilizes a post template. See the instructions [**here**](#use-post-template).
 
 ---
 
@@ -865,6 +857,8 @@ Do not take any further action. Leave further handling and review of the flag to
 
 <!-- markdownlint-restore -->
 
+This procedure utilizes a post template. See the instructions [**here**](#use-post-template).
+
 ---
 
 <a name="redirect-content-deletion-resolved"></a>
@@ -877,6 +871,8 @@ The user believes that they should delete the content because the topic is resol
 
 ![redirect-content-deletion-resolved|339x500, 75%](upload://Y1DwJNHfslREmAFdI8Q0SjvOKe.png)
 
+This procedure utilizes post templates. See the instructions [**here**](#use-post-template).
+
 ---
 
 <a name="redirect-content-deletion-tidy"></a>
@@ -888,6 +884,8 @@ The goal behind the request is that the user has no more need for the content an
 <!-- Source: https://github.com/arduino/forum-assets/blob/main/content/categories/staff/moderation/_topics/moderation-procedures/_assets/redirect-content-deletion-tidy.mmd -->
 
 ![redirect-content-deletion-tidy|278x460, 65%](upload://55iWUSlRCnrH7q5FEKSDC7Jgatc.png)
+
+This procedure utilizes a post template. See the instructions [**here**](#use-post-template).
 
 ---
 
@@ -926,6 +924,9 @@ Users often create topics in [categories](https://forum.arduino.cc/categories) w
    <!-- Source: https://github.com/arduino/forum-assets/blob/main/content/categories/staff/moderation/_topics/moderation-procedures/_assets/confirm-title-category.png -->
 
    ![Confirm category|486x331, 50%](https://europe1.discourse-cdn.com/arduino/original/4X/6/a/3/6a3a4f46600a335da2ec90659ce94c42a2e520dc.png)
+
+1. If the user's category choice was blatantly inappropriate (e.g., selecting the "**Uncategorized**" category), reply to warn the user. Use the "**Moved**" template, following the procedure [**here**](#use-post-template).
+   **❗** Skip this step if the category choice was reasonable.
 
 ---
 
@@ -1268,6 +1269,27 @@ In certain rare cases, the need might arise to suspend an account without there 
    The "**Change Owner**" dialog will open.
 1. Select the target account from the "**Please choose a new owner for the post**" field.
 1. Click the "**change ownership**" button.
+
+---
+
+<a name="use-post-template"></a>
+
+### [Use post template](#use-post-template)
+
+A collection of templates for posts made as part of common moderation procedures are provided.
+
+1. Click the "**Reply**" button on the topic you wish to reply to.
+   The post composer will open.
+1. Set the [editor mode switch](https://meta.discourse.org/t/introducing-our-new-composer-making-writing-on-discourse-easier-than-ever/369779#p-1791481-gear-turning-on-the-new-composer-2) on the composer toolbar to the "Markdown editor" position.
+1. Click the **+** icon on the post composer toolbar.
+   A menu will open.
+1. Select "**Insert template**" from the menu.
+   The list of templates will open in the right hand panel of the composer.
+1. Find the relevant template in the list. Click the clipboard icon to the right of that template.
+   The text of the template will be added to the post composer.
+1. The added text may contain [HTML comment](https://developer.mozilla.org/docs/Web/HTML/Guides/Comments) placeholders. If so, replace the placeholder with the appropriate text.
+1. Click the "**Reply**" button at the bottom of the composer to publish the reply.
+1. Make the post a "[Staff Post](#make-staff-post)".
 
 ---
 


### PR DESCRIPTION
We maintain a collection of templates for posts made as part of common moderation procedures. The Discourse Templates feature is used to make these templates quickly accessible to the moderators.

Previously the moderation procedure definitions did not utilize these templates. Instead, they either contained the content of a post template, or didn't provide any guidance regarding the post creation.