### PR TITLE
Update links to forum guidelines

### DIFF
--- a/content/categories/development-tools/ide-1-x/_topics/how-to-get-the-best-out-of-this-forum/README.md
+++ b/content/categories/development-tools/ide-1-x/_topics/how-to-get-the-best-out-of-this-forum/README.md
@@ -8,5 +8,5 @@
 
 - [Forum topic for related discussion](https://forum.arduino.cc/t/new-forum-instructions-feedback-and-comments/680710)
 - https://forum.arduino.cc/t/how-to-use-this-forum-please-read/145337
-- https://forum.arduino.cc/faq
+- https://forum.arduino.cc/guidelines
 - https://meta.discourse.org/t/discourse-new-user-guide/96331

--- a/content/categories/staff/_topics/faq-guidelines/README.md
+++ b/content/categories/staff/_topics/faq-guidelines/README.md
@@ -1,6 +1,8 @@
 # FAQ/Guidelines
 
-This content is accessed via [the "FAQ" link](https://forum.arduino.cc/faq) at the top of the forum.
+This content is accessed via the "**FAQ**" link at the top of the forum, which leads to the rendered content here:
+
+https://forum.arduino.cc/guidelines
 
 It is also recommended to new users as the "community guidelines" in a message shown on the post composer pane during their first two posts:
 
@@ -12,15 +14,12 @@ It is also recommended to new users as the "community guidelines" in a message s
 >
 > For more, see our [community guidelines](https://forum.arduino.cc/guidelines). This panel will only appear for your first 2 posts.
 
-The stock document is provided as part of the Discourse instance and is not Arduino-specific in any way.
-
 ## Published At
 
 - https://forum.arduino.cc/t/faq-guidelines/5
 
 ## Related
 
-- Page as rendered to users: https://forum.arduino.cc/faq
 - https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966
 - https://meta.discourse.org/t/discourse-new-user-guide/96331
 - Upstream source: https://github.com/discourse/discourse/blob/main/config/locales/server.en.yml (in the `en.guidelines_topic` mapping)


### PR DESCRIPTION
Discourse has changed the name of the page from "FAQ" (which is inappropriate since it is not actually a collection of frequently asked questions) to "Guidelines".

The canonical URL was changed accordingly. The previous URL still redirects to the new URL, but it is best to avoid a reliance on redirects.