### PR TITLE
Templates: Remove "Unhelpful or pointless post"

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -90,9 +90,6 @@
       "pattern": "^https://forum\\.arduino\\.cc/t/start-here-install-guide-faq/366571$"
     },
     {
-      "pattern": "^https://forum\\.arduino\\.cc/t/unhelpful-or-pointless-post/1087945$"
-    },
-    {
       "pattern": "^https://forum\\.arduino\\.cc/t/crosspost-deleted/1087957$"
     },
     {

--- a/content/categories/templates/_topics/unhelpful-or-pointless-post/1.md
+++ b/content/categories/templates/_topics/unhelpful-or-pointless-post/1.md
@@ -1,4 +1,0 @@
-Hello,
-I have deleted your post on the forum as it adds nothing useful to the discussion. You are of course welcome to contribute to the forum but before continuing please read https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966 before making any more posts or replies.
-
-Thank you.

--- a/content/categories/templates/_topics/unhelpful-or-pointless-post/README.md
+++ b/content/categories/templates/_topics/unhelpful-or-pointless-post/README.md
@@ -1,5 +1,0 @@
-# Unhelpful or pointless post
-
-## Published At
-
-https://forum.arduino.cc/t/unhelpful-or-pointless-post/1087945 (private)


### PR DESCRIPTION
This template was designed to be used to send a DM to the subject user after deleting their post. This is no longer necessary because we now delete all posts via flags, and this causes the forum software to automatically send the user a high quality DM (tailored according to the specific flag reason).