### PR TITLE
Moderation Procedures: Remove outdated note re: side effect of user flag

### DIFF
--- a/content/categories/staff/moderation/_topics/moderation-procedures/1.md
+++ b/content/categories/staff/moderation/_topics/moderation-procedures/1.md
@@ -147,9 +147,7 @@ Flags are shown on the ["**Review**" page](https://forum.arduino.cc/review). A m
 
 #### [User-submitted flags](#user-submitted-flags)
 
-Users can flag any post by clicking the **⚑** icon. The post may be automatically locked and/or hidden pending review based on the number of flags and ["trust level"](https://blog.discourse.org/2018/06/understanding-discourse-trust-levels/) of the flaggers.
-
-When submitting a flag, the user selects the category of the reason for the flag, which is shown on the ["Review" page](https://forum.arduino.cc/review).
+Users can flag any post by clicking the **⚑** icon. When submitting a flag, the user selects the category of the reason for the flag, which is shown on the ["Review" page](https://forum.arduino.cc/review).
 
 ---
 


### PR DESCRIPTION
Under certain conditions, the default Discourse settings cause user flagged topics to be closed, and flagged posts to be hidden. A note about this side effect was added to the "Moderation Procedures" document as part of the updates following the migration to Discourse.

Since that time, these side effects have been evaluated and determined to cause more harm than good. For this reason, the setting have been adjusted so that user flags only generate a review item (spam detections still result in the item being hidden, and these cover most of the malicious activity). That settings change rendered the note in the "Moderation Procedures" document incorrect.