### PR TITLE
Moderation Procedures: Add note re: false positive flags

### DIFF
--- a/content/categories/staff/moderation/_topics/moderation-procedures/1.md
+++ b/content/categories/staff/moderation/_topics/moderation-procedures/1.md
@@ -139,6 +139,12 @@ Flags are used to bring things to the attention of the moderators. They may be s
 
 Flags are shown on the ["**Review**" page](https://forum.arduino.cc/review). A moderator must review each flag and decide how it should be handled.
 
+---
+
+⚠ False positives are common. Be sure to carefully evaluate each review item in order to avoid unjust actions.
+
+---
+
 <a name="sources-of-flags"></a>
 
 ### [Sources of flags](#sources-of-flags)
@@ -159,7 +165,7 @@ The forum software does automated detection of potential problems with user acco
 
 ---
 
-❗ The automated systems are prone to false positives. Please treat these flags as solely a suggestion from the automated system, not as conclusive evidence that something is wrong with the flagged item.
+❗ Automated systems are especially prone to false positives. Please treat these flags as solely a suggestion from the automated system, not as conclusive evidence that something is wrong with the flagged item.
 
 ---
 


### PR DESCRIPTION
Previously, a note was only present under the section for flags from automated systems. False positives also occur in user submitted flags. For this reason, it will be wise to add a note under the overall flags section.

The new note renders the existing note under the section for automated systems somewhat redundant. However, since false positives are most common from the automated systems, it is worth having a second note under that section to ensure the reader sees this important statement.