### PR TITLE
Moderation Procedures: Update anchor IDs

### DIFF
--- a/content/categories/staff/moderation/_topics/moderation-procedures/1.md
+++ b/content/categories/staff/moderation/_topics/moderation-procedures/1.md
@@ -459,8 +459,9 @@ The procedures for handling the flags from either of the first two sources are d
 ---
 
 <a name="sockpuppets-flag"></a>
+<a name="flags-from-flag-sockpuppets-system"></a>
 
-### [Flags from "flag_sockpuppets" system](#sockpuppets-flag)
+### [Flags from "flag_sockpuppets" system](#flags-from-flag-sockpuppets-system)
 
 These flags have the "Spam" reason. However, they are raised based on attributes of the post author's account, not based on the post content.
 
@@ -500,8 +501,9 @@ These flags are automatically raised by the **`@system`** user account when a ne
 ---
 
 <a name="needs-approval-flag-for-post"></a>
+<a name="post-flagged-as-needs-approval"></a>
 
-### [Post flagged as "Needs Approval"](#needs-approval-flag-for-post)
+### [Post flagged as "Needs Approval"](#post-flagged-as-needs-approval)
 
 This flag is created by **`@system`** when an automated system determines that a post should be reviewed by a moderator.
 
@@ -587,8 +589,9 @@ This system flags topics which are determined to miscategorized for the language
 ---
 
 <a name="needs-approval-flag-for-account"></a>
+<a name="account-flagged-as-needs-approval"></a>
 
-### [Account flagged as "Needs Approval"](#needs-approval-flag-for-account)
+### [Account flagged as "Needs Approval"](#account-flagged-as-needs-approval)
 
 This flag is created by **`@system`** when a user account creation is detected as possibly malicious. The account must be reviewed by a moderator.
 


### PR DESCRIPTION
Although not a part of the Markdown specification, it is common practice for Markdown renderers to create an anchor for each heading, which has an ID that is the slugified heading title.

The markdown-toc table of contents generation tool used with this document is designed for that practice, and thus links the ToC items to anchors with those expected IDs. Unfortunately Discourse does not comply with that common practice. They instead create anchors with a non-standard anchor format that includes the heading count (meaning IDs change every time a new heading is added to a document). For this reason, it is necessary to manually add anchors with the correct permanent ID to the document.

Some anchors were not updated at the time the title text was modified. This broke those table of content links. Anchors with correct IDs are hereby added. The former anchors are left in place to ensure any external links to these headings continue to work as intended.