### PR TITLE
Moderation Procedures: Replace legacy anchors

### DIFF
--- a/content/categories/staff/moderation/_topics/moderation-procedures/1.md
+++ b/content/categories/staff/moderation/_topics/moderation-procedures/1.md
@@ -775,6 +775,7 @@ This procedure utilizes a post template. See the instructions [**here**](#use-po
 
 ---
 
+<a name="deal-with-cross-post"></a>
 <a name="handle-cross-post"></a>
 
 ### [Handle cross-post](#handle-cross-post)
@@ -833,6 +834,7 @@ If multiple cross-posts have valuable replies, they must be preserved by merging
 
 ---
 
+<a name="deal-with-inappropriate-behavior"></a>
 <a name="handle-inappropriate-behavior"></a>
 
 ### [Handle inappropriate behavior](#handle-inappropriate-behavior)


### PR DESCRIPTION
HTML anchors are added for each heading in this document in order to allow linking to a specific section of the document.

In order to work with the "markdown-toc" table of contents generation tool, the canonical anchor IDs are the slugified text of the heading. This means the canonical anchor ID must be updated when a heading title is changed.

In this event, it is best practices to also leave the previous anchor in place, in order to ensure any external links targeting the anchor continue to work as expected. That was not done at the time of a recent change to some heading titles.

The legacy anchors are hereby restored.