### PR TITLE
Exclude HTTP status code 429 from link check

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -129,7 +129,7 @@
       "pattern": "^https://support\\.arduino\\.cc/hc"
     }
   ],
-  "retryOn429": true,
+  "retryOn429": false,
   "retryCount": 3,
-  "aliveStatusCodes": [200, 206]
+  "aliveStatusCodes": [200, 206, 429]
 }

--- a/content/categories/staff/moderation/_topics/moderation-procedures/1.md
+++ b/content/categories/staff/moderation/_topics/moderation-procedures/1.md
@@ -399,7 +399,7 @@ There are typically three possible conclusions for a flag review:
 
 <a name="post-flagged-as-inappropriate-benign"></a>
 
-#### [If the post does not violate the rules](#post-flagged-as-inapproppriate-benign)
+#### [If the post does not violate the rules](#post-flagged-as-inappropriate-benign)
 
 1. Click the <kbd>**No ▾**</kbd> button.
    A menu will open.
@@ -479,7 +479,7 @@ Flags with the "Spam" reason come from three separate sources:
 - The "flag_sockpuppets" automated system.
   These flags are raised by the **`@system`** user account.
 
-Since special handling is indicated for the flags from the "flag_sockpuppets" system, the procedures for handling those flags are defined in a separate section of this document: [**here**](#sockpuppets_flag).
+Since special handling is indicated for the flags from the "flag_sockpuppets" system, the procedures for handling those flags are defined in a separate section of this document: [**here**](#flags-from-flag_sockpuppets-system).
 
 The procedures for handling the flags from either of the first two sources are defined below:
 


### PR DESCRIPTION
The assets and documentation content contains many links. The project infrastructure checks the validity of these links.

Unfortunately the links to forum pages now return 429 status codes to the link checker tool. These cause the link check to fail spuriously. This is problematic both because it will result in a poor experience for contributors, and because it causes the project maintainers to disregard the failed check, and thus they may miss true positive detections.

The spurious failures are avoided by configure the link checker tool to consider links that return a 429 status code to be functional. This is not ideal, but is the only available resolution.