### PR TITLE
Templates: Correct wording of crosspost merge warning

### DIFF
--- a/content/categories/templates/_topics/crosspost-merged/1.md
+++ b/content/categories/templates/_topics/crosspost-merged/1.md
@@ -1,4 +1,4 @@
-I have deleted your other post on the same subject <!-- TODO: @username -->.
+I have merged your other post on the same subject <!-- TODO: @username -->.
 
 Crossposting is against the Arduino Forum [rules](https://forum.arduino.cc/faq#keep-tidy). The reason is that duplicate posts can waste the time of the people trying to help. Someone might spend a lot of time investigating and writing a detailed answer on one topic, without knowing that someone else already did the same in the other topic.
 


### PR DESCRIPTION
Previously, due to a copy/paste error, this template contained the wording for the template used when the crosspost was deleted rather than merged.