### PR TITLE
Mention advanced capabilities in "About the Bughopper category" post

### DIFF
--- a/content/categories/official-hardware/accessories/bughopper/_topics/about-the-bughopper-category/1.md
+++ b/content/categories/official-hardware/accessories/bughopper/_topics/about-the-bughopper-category/1.md
@@ -1,8 +1,10 @@
 Discussion about the **Bughopper**
 
-The **Arduino Bughopper** is a USB to UART adapter for use with the JCTL header on the **UNO Q** and **VENTUNO Q** boards.
+The **Arduino Bughopper** is a tool for use with the the **UNO Q** and **VENTUNO Q** boards.
 
-The **Bughopper** provides low level access to the shell of the board's Linux machine. It is compatible with the 1.8 V logic level of the JCTL header's UART pins.
+The **Bughopper** is designed to plug onto the JCTL header on these boards. It is compatible with the 1.8 V logic level of the JCTL header's UART pins.
+
+The fundamental utility of the **Bughopper** is to serve as a USB to UART adapter that provides low level access to the shell of the board's Linux machine. The **Bughopper** also supports more advanced use cases thanks to having several GPIO pins connected to the additional pins on the JCTL header. This facilitates advanced operations that require control over the VBUS power switch, PMIC reset, bootstrap, or arbitrary signaling with the microprocessor via a dedicated I/O pin.
 
 Use this category for topics where the primary subject matter is the **Arduino Bughopper**.
 


### PR DESCRIPTION
Previously, the "About the Bughopper category" post only mentioned the use as a basic USB to serial adapter.

The Bughopper has also been designed to support advanced use cases specifically tailored to the target boards. Mentioning the existence of these capabilities will bring them to the awareness of the forum members.