### PR TITLE
Remove VENTUNO Q mention from UNO Media Carrier category description

### DIFF
--- a/content/categories/official-hardware/uno-family/uno-media-carrier/_topics/about-the-uno-media-carrier-category/1.md
+++ b/content/categories/official-hardware/uno-family/uno-media-carrier/_topics/about-the-uno-media-carrier-category/1.md
@@ -1,6 +1,6 @@
 Discussion about the **UNO Media Carrier**
 
-The **Arduino UNO Media Carrier** facilitates connection of multimedia peripherals to the high-speed connectors on the bottom of the **UNO Q** and **VENTUNO Q** boards.
+The **Arduino UNO Media Carrier** facilitates connection of multimedia peripherals to the high-speed connectors on the bottom of the **UNO Q** board.
 
 The **UNO Media Carrier** provides standard connectors for:
 


### PR DESCRIPTION
Although the VENTUNO Q is electrically compatible with the UNO Media Carrier, the carrier is currently targeted only to the UNO Q.

The misleading mention of VENTUNO Q is hereby removed from the description of the "UNO Media Carrier" category.